### PR TITLE
update release docs again, add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,27 @@
+# Cruft
+*.sublime-workspace
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+.tmp
+npm-debug.log
+
+# Code / build
+coverage
+node_modules
+bower_components
+demo
+test
+karma*
+webpack*
+.eslint*
+.editor*
+.travis*

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -140,21 +140,30 @@ coverage/
 
 ## Releases
 
+**IMPORTANT - NPM**: To correctly run `preversion` your first step is to make
+sure that you have a very modern `npm` binary:
+
+```
+$ npm install -g npm
+```
+
 Built files in `dist/` should **not** be committeed during development or PRs.
 Instead we _only_ build and commit them for published, tagged releases. So
 the basic workflow is:
 
 ```
-# make sure everything is committed and up to date on master
-$ npm run build
-# this will clean and rebuild dist/ for publication
-$ git add dist/
-$ git commit -m "build dist for release"
+# Make sure you have a clean, up-to-date `master`
+$ git pull
+$ git status # (should be no changes)
 
+# Choose a semantic update for the new version.
+# If you're unsure, read about semantic versioning at http://semver.org/
 $ npm version major|minor|patch -m "Version %s - INSERT_REASONS"
-# this will semantically update the version in package.json
-# if you're unsure about which option to use, read about semantic versioning [here](http://semver.org/)
-# ... the project is now patched and committed to git (but unpushed).
+
+# ... the `dist/` and `lib/` directories are now built, `package.json` is
+# updated, and the appropriate files are committed to git (but unpushed).
+#
+# *Note*: `lib/` is uncommitted, but built and must be present to push to npm.
 
 # Check that everything looks good in last commit and push.
 $ git diff HEAD^ HEAD
@@ -165,6 +174,11 @@ $ git push && git push --tags
 $ npm publish
 ```
 
+And you've published!
+
+For additional information on the underlying NPM technologies and approaches,
+please review:
+
 * [`npm version`](https://docs.npmjs.com/cli/version): Runs verification,
   builds `dist/` and `lib/` via `scripts` commands.
     * Our scripts also run the applicable `git` commands, so be very careful
@@ -172,14 +186,3 @@ $ npm publish
 * [`npm publish`](https://docs.npmjs.com/cli/publish): Uploads to NPM.
     * **NOTE**: We don't _build_ in `prepublish` because of the
       [`npm install` runs `npm prepublish` bug](https://github.com/npm/npm/issues/3059)
-
-Side note: `npm publish` runs `npm prepublish` under the hood, which does the
-build.
-
-**Note - NPM**: To correctly run `preversion`, etc. scripts, please make sure
-you have a very modern `npm` binary:
-
-```
-$ npm install -g npm
-```
-


### PR DESCRIPTION
cc/ @angelanicholas 

fun story!  if you don't have an `.npmignore` npm uses your `.gitignore` instead, which is why components weren't getting included correctly (npm was ignoring lib)

I added an `.npmignore` and updated the docs again after a review from Roemer.