### PR TITLE
phantomjs needs es6 polyfill when using victory-animation because of …

### DIFF
--- a/karma.conf.dev.js
+++ b/karma.conf.dev.js
@@ -14,6 +14,8 @@ module.exports = function (config) {
     browsers: ["PhantomJS"],
     basePath: ".", // repository root.
     files: [
+      // es6 polyfill for phantom
+      "node_modules/babel-core/browser-polyfill.js",
       // Sinon has issues with webpack. Do global include.
       "node_modules/sinon/pkg/sinon.js",
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,6 +24,8 @@ module.exports = function (config) {
       "test/client/main.js": ["webpack"]
     },
     files: [
+      // es6 polyfill for phantom
+      "node_modules/babel-core/browser-polyfill.js",
       // Sinon has issues with webpack. Do global include.
       "node_modules/sinon/pkg/sinon.js",
 


### PR DESCRIPTION
…d3-ease

cc/ @angelanicholas 

This should fix the weird test failure you've been seeing that has prevented you from publishing.  It adds an es6 polyfill for phantomjs.  It's necessary because `d3-ease` is published as non-transpiled es6.