### PR TITLE
Small renderables

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -58,7 +58,7 @@ class App extends React.Component {
       this.setState({
         data: getData()
       });
-    }, 5000);
+    }, 3000);
   }
 
   render() {

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -27,7 +27,7 @@ class App extends React.Component {
     super(props);
     this.state = {
       data: this.props.data,
-      sliceColors: [
+      colorScale: [
         "#D85F49",
         "#F66D3B",
         "#D92E1D",
@@ -69,8 +69,9 @@ class App extends React.Component {
         <VictoryPie
           style={{
             parent: {border: "1px solid #ccc", margin: 20},
-            labels: {fontSize: 20, padding: 100}
+            labels: {fontSize: 20, padding: 100, fill: "white"}
           }}
+          colorScale="greyscale"
         />
 
         <VictoryPie style={this.state.style} innerRadius={140}/>
@@ -90,7 +91,7 @@ class App extends React.Component {
           data={this.state.data}
           innerRadius={100}
           animate={{velocity: 0.03}}
-          sliceColors={this.state.sliceColors}
+          colorScale={this.state.colorScale}
         />
 
         <VictoryPie

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -10,7 +10,7 @@ const rand = function () {
 
 const getData = function () {
   return [
-    { x: "<5", y: rand() },
+    { x: "<5", y: rand(), label: "A" },
     { x: "5-13", y: rand() },
     { x: "14-17", y: rand() },
     { x: "18-24", y: rand() },
@@ -86,7 +86,6 @@ class App extends React.Component {
         <VictoryPie style={this.state.style} endAngle={90} startAngle={-90}/>
 
         <VictoryPie
-          padding={{top: 30, left: 30}}
           style={this.state.style}
           data={this.state.data}
           innerRadius={100}

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -10,7 +10,7 @@ const rand = function () {
 
 const getData = function () {
   return [
-    { x: "<5", y: rand(), label: "A" },
+    { x: "<5", y: rand(), label: "A", fill: "grey" },
     { x: "5-13", y: rand() },
     { x: "14-17", y: rand() },
     { x: "18-24", y: rand() },

--- a/docs/ecology.md
+++ b/docs/ecology.md
@@ -55,7 +55,8 @@ Specify a `padAngle` to add space between adjacent slices:
   endAngle={90}
   innerRadius={140}
   padAngle={5}
-  startAngle={-90}/>
+  startAngle={-90}
+/>
 ```
 
 Here's an example of a donut chart with custom data and colors
@@ -79,7 +80,7 @@ Here's an example of a donut chart with custom data and colors
     {x: "≥65", y: 7502}
   ]}
   innerRadius={110}
-  sliceColors={[
+  colorScale={[
     "#D85F49",
     "#F66D3B",
     "#D92E1D",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chai": "^3.2.0",
     "mocha": "^2.2.5",
     "react": "0.14.x",
+    "react-addons-test-utils": "0.14.x",
     "react-dom": "0.14.x",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "builder": "~2.2.2",
     "builder-victory-component": "~0.0.5",
-    "d3": "^3.5.6",
+    "d3-shape": "^0.2.0",
     "victory-animation": "^0.0.12",
     "victory-util": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "builder-victory-component": "~0.0.5",
     "d3-shape": "^0.2.0",
     "victory-animation": "^0.0.12",
+    "victory-label": "^0.1.6",
     "victory-util": "^2.0.2"
   },
   "devDependencies": {

--- a/src/components/slice-label.jsx
+++ b/src/components/slice-label.jsx
@@ -1,0 +1,53 @@
+import _ from "lodash";
+import React, { PropTypes } from "react";
+import Radium from "radium";
+import {VictoryAnimation} from "victory-animation";
+
+@Radium
+export default class Slice extends React.Component {
+  static propTypes = {
+    animate: PropTypes.object,
+    data: PropTypes.any,
+    label: PropTypes.any,
+    transform: PropTypes.string,
+    style: PropTypes.object
+  };
+
+  evaluateStyle(style) {
+    return _.transform(style, (result, value, key) => {
+      result[key] = this.evaluateProp(value);
+    });
+  }
+
+  evaluateProp(prop) {
+    return _.isFunction(prop) ? prop.call(this, this.props.data) : prop;
+  }
+
+  renderLabel(props) {
+    const style = this.evaluateStyle(props.style)
+    return (
+      <text
+        dy=".35em"
+        transform={props.transform}
+        style={style}
+      >
+        {this.evaluateProp(props.label)}
+      </text>
+    );
+  }
+
+  render() {
+    if (this.props.animate) {
+      // Do less work by having `VictoryAnimation` tween only values that
+      // make sense to tween. In the future, allow customization of animated
+      // prop whitelist/blacklist?
+      const animateData = _.pick(this.props, ["style", "data", "transform"]);
+      return (
+        <VictoryAnimation {...this.props.animate} data={animateData}>
+          {(props) => <SliceLabel {...this.props} {...props} animate={null}/>}
+        </VictoryAnimation>
+      );
+    }
+    return this.renderLabel(this.props);
+  }
+}

--- a/src/components/slice-label.jsx
+++ b/src/components/slice-label.jsx
@@ -4,12 +4,13 @@ import Radium from "radium";
 import {VictoryAnimation} from "victory-animation";
 
 @Radium
-export default class Slice extends React.Component {
+export default class SliceLabel extends React.Component {
   static propTypes = {
     animate: PropTypes.object,
     data: PropTypes.any,
     label: PropTypes.any,
-    transform: PropTypes.string,
+    positionFunction: PropTypes.func,
+    slice: PropTypes.object,
     style: PropTypes.object
   };
 
@@ -24,12 +25,12 @@ export default class Slice extends React.Component {
   }
 
   renderLabel(props) {
-    const style = this.evaluateStyle(props.style)
+    const position = props.positionFunction.call(this, props.slice);
     return (
       <text
         dy=".35em"
-        transform={props.transform}
-        style={style}
+        transform={`translate( ${position})`}
+        style={this.evaluateStyle(props.style)}
       >
         {this.evaluateProp(props.label)}
       </text>
@@ -41,7 +42,7 @@ export default class Slice extends React.Component {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
-      const animateData = _.pick(this.props, ["style", "data", "transform"]);
+      const animateData = _.pick(this.props, ["style", "data", "slice"]);
       return (
         <VictoryAnimation {...this.props.animate} data={animateData}>
           {(props) => <SliceLabel {...this.props} {...props} animate={null}/>}

--- a/src/components/slice-label.jsx
+++ b/src/components/slice-label.jsx
@@ -2,17 +2,26 @@ import _ from "lodash";
 import React, { PropTypes } from "react";
 import Radium from "radium";
 import {VictoryAnimation} from "victory-animation";
+import {VictoryLabel} from "victory-label";
+
 
 @Radium
 export default class SliceLabel extends React.Component {
   static propTypes = {
     animate: PropTypes.object,
-    data: PropTypes.any,
-    label: PropTypes.any,
+    labelComponent: PropTypes.any,
     positionFunction: PropTypes.func,
     slice: PropTypes.object,
     style: PropTypes.object
   };
+
+  getCalculatedValues(props) {
+    const position = props.positionFunction.call(this, props.slice);
+    this.x = position[0];
+    this.y = position[1];
+    this.data = props.slice.data;
+    this.label = this.data.label ? `${this.evaluateProp(this.data.label)}` : `${this.data.x}`;
+  }
 
   evaluateStyle(style) {
     return _.transform(style, (result, value, key) => {
@@ -21,20 +30,41 @@ export default class SliceLabel extends React.Component {
   }
 
   evaluateProp(prop) {
-    return _.isFunction(prop) ? prop.call(this, this.props.data) : prop;
+    return _.isFunction(prop) ? prop.call(this, this.data) : prop;
+  }
+
+  renderLabelComponent(props) {
+    const component = props.labelComponent;
+    const style = this.evaluateStyle(_.merge({padding: 0}, props.style, component.props.style));
+    const children = component.props.children || this.label;
+    const newProps = {
+      x: component.props.x || this.x,
+      y: component.props.y || this.y,
+      data: this.data, // Pass data for custom label component to access
+      textAnchor: component.props.textAnchor || "start",
+      verticalAnchor: component.props.verticalAnchor || "middle",
+      style
+    };
+    return React.cloneElement(component, newProps, children);
+  }
+
+  renderVictoryLabel(props) {
+    const style = this.evaluateStyle(_.merge({padding: 0}, props.style));
+    return (
+      <VictoryLabel
+        x={this.x}
+        y={this.y}
+        data={this.data}
+        style={style}
+      >
+        {this.label}
+      </VictoryLabel>
+    );
   }
 
   renderLabel(props) {
-    const position = props.positionFunction.call(this, props.slice);
-    return (
-      <text
-        dy=".35em"
-        transform={`translate( ${position})`}
-        style={this.evaluateStyle(props.style)}
-      >
-        {this.evaluateProp(props.label)}
-      </text>
-    );
+    return props.labelComponent ?
+      this.renderLabelComponent(props) : this.renderVictoryLabel(props);
   }
 
   render() {
@@ -42,12 +72,14 @@ export default class SliceLabel extends React.Component {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
-      const animateData = _.pick(this.props, ["style", "data", "slice"]);
+      const animateData = _.pick(this.props, ["style", "slice"]);
       return (
         <VictoryAnimation {...this.props.animate} data={animateData}>
           {(props) => <SliceLabel {...this.props} {...props} animate={null}/>}
         </VictoryAnimation>
       );
+    } else {
+      this.getCalculatedValues(this.props);
     }
     return this.renderLabel(this.props);
   }

--- a/src/components/slice.jsx
+++ b/src/components/slice.jsx
@@ -18,11 +18,16 @@ export default class Slice extends React.Component {
     });
   }
 
+  getStyles() {
+    const dataStyles = _.omit(this.props.slice.data, ["x", "y", "label"]);
+    return this.evaluateStyle(_.merge({}, this.props.style, dataStyles));
+  }
+
   renderSlice(props) {
     return (
       <path
         d={props.pathFunction.call(this, props.slice)}
-        style={this.evaluateStyle(props.style)}
+        style={this.getStyles()}
       />
     );
   }

--- a/src/components/slice.jsx
+++ b/src/components/slice.jsx
@@ -7,7 +7,6 @@ import {VictoryAnimation} from "victory-animation";
 export default class Slice extends React.Component {
   static propTypes = {
     animate: PropTypes.object,
-    data: PropTypes.object,
     slice: PropTypes.object,
     pathFunction: PropTypes.func,
     style: PropTypes.object
@@ -15,7 +14,7 @@ export default class Slice extends React.Component {
 
   evaluateStyle(style) {
     return _.transform(style, (result, value, key) => {
-      result[key] = _.isFunction(value) ? value.call(this, this.props.data) : value;
+      result[key] = _.isFunction(value) ? value.call(this, this.props.slice.data) : value;
     });
   }
 
@@ -33,7 +32,7 @@ export default class Slice extends React.Component {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
-      const animateData = _.pick(this.props, ["style", "data", "slice"]);
+      const animateData = _.pick(this.props, ["style", "slice"]);
       return (
         <VictoryAnimation {...this.props.animate} data={animateData}>
           {(props) => <Slice {...this.props} {...props} animate={null}/>}

--- a/src/components/slice.jsx
+++ b/src/components/slice.jsx
@@ -7,23 +7,23 @@ import {VictoryAnimation} from "victory-animation";
 export default class Slice extends React.Component {
   static propTypes = {
     animate: PropTypes.object,
-    data: PropTypes.any,
-    path: PropTypes.string,
+    data: PropTypes.object,
+    slice: PropTypes.object,
+    pathFunction: PropTypes.func,
     style: PropTypes.object
   };
 
   evaluateStyle(style) {
     return _.transform(style, (result, value, key) => {
-      result[key] = _.isFunction(value) ? prop.call(this, this.props.data) : value;
+      result[key] = _.isFunction(value) ? value.call(this, this.props.data) : value;
     });
   }
 
   renderSlice(props) {
-    const style = this.evaluateStyle(props.style)
     return (
       <path
-        d={props.path}
-        style={style}
+        d={props.pathFunction.call(this, props.slice)}
+        style={this.evaluateStyle(props.style)}
       />
     );
   }
@@ -33,7 +33,7 @@ export default class Slice extends React.Component {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
-      const animateData = _.pick(this.props, ["style", "data", "path"]);
+      const animateData = _.pick(this.props, ["style", "data", "slice"]);
       return (
         <VictoryAnimation {...this.props.animate} data={animateData}>
           {(props) => <Slice {...this.props} {...props} animate={null}/>}

--- a/src/components/slice.jsx
+++ b/src/components/slice.jsx
@@ -1,0 +1,45 @@
+import _ from "lodash";
+import React, { PropTypes } from "react";
+import Radium from "radium";
+import {VictoryAnimation} from "victory-animation";
+
+@Radium
+export default class Slice extends React.Component {
+  static propTypes = {
+    animate: PropTypes.object,
+    data: PropTypes.any,
+    path: PropTypes.string,
+    style: PropTypes.object
+  };
+
+  evaluateStyle(style) {
+    return _.transform(style, (result, value, key) => {
+      result[key] = _.isFunction(value) ? prop.call(this, this.props.data) : value;
+    });
+  }
+
+  renderSlice(props) {
+    const style = this.evaluateStyle(props.style)
+    return (
+      <path
+        d={props.path}
+        style={style}
+      />
+    );
+  }
+
+  render() {
+    if (this.props.animate) {
+      // Do less work by having `VictoryAnimation` tween only values that
+      // make sense to tween. In the future, allow customization of animated
+      // prop whitelist/blacklist?
+      const animateData = _.pick(this.props, ["style", "data", "path"]);
+      return (
+        <VictoryAnimation {...this.props.animate} data={animateData}>
+          {(props) => <Slice {...this.props} {...props} animate={null}/>}
+        </VictoryAnimation>
+      );
+    }
+    return this.renderSlice(this.props);
+  }
+}

--- a/src/components/victory-pie.jsx
+++ b/src/components/victory-pie.jsx
@@ -78,10 +78,7 @@ export default class VictoryPie extends React.Component {
      * to be applied to each data point. If this prop is not specified, the x value
      * of each data point will be used as a label.
      */
-    labels: PropTypes.oneOfType([
-      PropTypes.array,
-      PropTypes.func
-    ]),
+    labelComponent: PropTypes.element,
     /**
      * The padAngle prop determines the amount of separation between adjacent data slices
      * in number of degrees
@@ -217,13 +214,6 @@ export default class VictoryPie extends React.Component {
   }
 
   renderData() {
-    const getTextFromProps = (index) => {
-      if (!this.props.labels) {
-        return undefined;
-      }
-      return _.isArray(this.props.labels) ? this.props.labels[index] : this.props.labels;
-    };
-
     const slices = this.pie(this.props.data);
     const sliceComponents = _.map(slices, (slice, index) => {
       const fill = this.colorScale[index % this.colorScale.length];
@@ -234,13 +224,11 @@ export default class VictoryPie extends React.Component {
             animate={this.props.animate}
             slice={slice}
             pathFunction={this.slice}
-            data={slice.data}
             style={style}
           />
           <SliceLabel
             animate={this.props.animate}
-            data={slice.data}
-            label={getTextFromProps(index) || slice.data.x}
+            labelComponent={this.props.labelComponent}
             style={this.style.labels}
             positionFunction={this.labelPosition.centroid}
             slice={slice}

--- a/src/components/victory-pie.jsx
+++ b/src/components/victory-pie.jsx
@@ -1,9 +1,8 @@
-import d3Shape from "d3-shape";
 import _ from "lodash";
 import React, { PropTypes } from "react";
 import Radium from "radium";
+import d3Shape from "d3-shape";
 import Util from "victory-util";
-import {VictoryAnimation} from "victory-animation";
 import Slice from "./slice";
 import SliceLabel from "./slice-label";
 
@@ -74,10 +73,10 @@ export default class VictoryPie extends React.Component {
      */
     innerRadius: Util.PropTypes.nonNegative,
     /**
-     * This prop specifies the labels that will be applied to your data. This prop can be passed in as
-     * an array of values, in the same order as your data, or as a function to be applied
-     * to each data point. If this prop is not specified, the x value of each data point will
-     * be used as a label
+     * This prop specifies the labels that will be applied to your data. This prop can be
+     * passed in as an array of values, in the same order as your data, or as a function
+     * to be applied to each data point. If this prop is not specified, the x value
+     * of each data point will be used as a label.
      */
     labels: PropTypes.oneOfType([
       PropTypes.array,
@@ -223,7 +222,7 @@ export default class VictoryPie extends React.Component {
         return undefined;
       }
       return _.isArray(this.props.labels) ? this.props.labels[index] : this.props.labels;
-    }
+    };
 
     const slices = this.pie(this.props.data);
     const sliceComponents = _.map(slices, (slice, index) => {
@@ -232,15 +231,19 @@ export default class VictoryPie extends React.Component {
       return (
         <g key={index}>
           <Slice
-            path={this.slice(slice)}
+            animate={this.props.animate}
+            slice={slice}
+            pathFunction={this.slice}
             data={slice.data}
             style={style}
           />
           <SliceLabel
+            animate={this.props.animate}
             data={slice.data}
             label={getTextFromProps(index) || slice.data.x}
             style={this.style.labels}
-            transform={`translate( ${this.labelPosition.centroid(slice)})`}
+            positionFunction={this.labelPosition.centroid}
+            slice={slice}
           />
         </g>
       );
@@ -250,22 +253,7 @@ export default class VictoryPie extends React.Component {
   }
 
   render() {
-    if (this.props.animate) {
-      // Do less work by having `VictoryAnimation` tween only values that
-      // make sense to tween. In the future, allow customization of animated
-      // prop whitelist/blacklist?
-      const animateData = _.pick(this.props, [
-        "data", "endAngle", "height", "innerRadius", "padAngle", "padding",
-        "sliceColors", "startAngle", "style", "width"
-      ]);
-      return (
-        <VictoryAnimation {...this.props.animate} data={animateData}>
-          {(props) => <VictoryPie {...this.props} {...props} animate={null}/>}
-        </VictoryAnimation>
-      );
-    } else {
-      this.getCalculatedValues(this.props);
-    }
+    this.getCalculatedValues(this.props);
     const style = this.style.parent;
     const xOffset = this.radius + this.padding.left;
     const yOffset = this.radius + this.padding.top;

--- a/test/client/spec/components/victory-pie.spec.jsx
+++ b/test/client/spec/components/victory-pie.spec.jsx
@@ -1,18 +1,33 @@
 /**
  * Client tests
  */
-// import React from "react/addons";
-// import Component from "src/components/victory-pie";
-
+import React from "react";
+import ReactDOM from "react-dom";
+import VictoryPie from "src/components/victory-pie";
 // Use `TestUtils` to inject into DOM, simulate events, etc.
 // See: https://facebook.github.io/react/docs/test-utils.html
-// const TestUtils = React.addons.TestUtils;
+import TestUtils from "react-addons-test-utils";
 
-describe("components/victory-pie", () => {
+const getElement = function (output, tagName) {
+  return ReactDOM.findDOMNode(
+    TestUtils.findRenderedDOMComponentWithTag(output, tagName)
+  );
+};
 
-  it("has expected content with deep render", () => {
-    return true;
+let renderedComponent;
+
+describe("components/victory-bar", () => {
+  describe("default component rendering", () => {
+    before(() => {
+      renderedComponent = TestUtils.renderIntoDocument(<VictoryPie/>);
+    });
+
+    it("renders an svg with the correct width and height", () => {
+
+      const svg = getElement(renderedComponent, "svg");
+      // default width and height
+      expect(svg.style.width).to.equal(`${VictoryPie.defaultProps.width}px`);
+      expect(svg.style.height).to.equal(`${VictoryPie.defaultProps.height}px`);
+    });
   });
-
-
 });


### PR DESCRIPTION
this PR
- switches to d3 modules
- breaks pie into small renderables
- supports functional styles
- renames `sliceColors` -> `colorScale` and adds support for default color scales from util, updates the docs to reflect this naming change
- adds a `labelComponent` prop
- adds test coverage

closes #29 
closes #28 
closes #27 
closes #26 