### PR TITLE
Refactors VictoryPie to support injected Slices

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -1,8 +1,10 @@
 /*global window:false*/
 import _ from "lodash";
-import React from "react";
+import React, {PropTypes} from "react";
 import Radium from "radium";
 import {VictoryPie} from "../src/index";
+
+import Slice from "../src/components/slice";
 
 const rand = () => Math.max(Math.floor(Math.random() * 10000), 1000);
 
@@ -17,6 +19,24 @@ const getData = () => {
     { x: "≥65", y: rand() }
   ];
 };
+
+
+class MySlice extends React.Component {
+  static propTypes = {
+    slice: PropTypes.object
+  };
+
+  handleClick() {
+  }
+
+  render() {
+    return (
+      <g onClick={this.handleClick.bind(this)}>
+        <Slice {...this.props} />
+      </g>
+    );
+  }
+}
 
 @Radium
 export default class App extends React.Component {
@@ -109,6 +129,15 @@ export default class App extends React.Component {
 
         <VictoryPie
           data={_.range(0, 6).map((i) => [i, Math.random()])}
+          x={0}
+          y={1}
+          style={this.state.style}
+          colorScale="qualitative"
+        />
+
+        <VictoryPie
+          animate={{velocity: 0.03}}
+          SliceComponent={MySlice}
           x={0}
           y={1}
           style={this.state.style}

--- a/src/components/victory-pie.jsx
+++ b/src/components/victory-pie.jsx
@@ -187,7 +187,23 @@ export default class VictoryPie extends React.Component {
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string)
-    ])
+    ]),
+    /**
+     * The SliceComponent prop specifies a React component to use in building each slice in
+     * your pie chart.
+     * The value will be used in JSX.
+     * But, by default, Victory's standard Slice component will be used.
+     * @examples 'Slice', 'props => <Slice {...props} />'
+     */
+    SliceComponent: PropTypes.func,
+    /**
+     * The SliceLabelComponent prop specifies a React component to use in building each label in
+     * your pie chart.
+     * The value will be used in JSX.
+     * But, by default, Victory's standard SliceLabel component will be used.
+     * @examples 'SliceLabel', 'props => <SliceLabel {...props} />
+     */
+    SliceLabelComponent: PropTypes.func
   };
 
   static defaultProps = {
@@ -216,7 +232,9 @@ export default class VictoryPie extends React.Component {
     standalone: true,
     width: 400,
     x: "x",
-    y: "y"
+    y: "y",
+    SliceComponent: Slice,
+    SliceLabelComponent: SliceLabel
   };
 
   static getDomain = Domain.getDomain.bind(Domain);
@@ -227,12 +245,12 @@ export default class VictoryPie extends React.Component {
     const sliceStyle = merge({}, style.data, {fill});
     return (
       <g key={index}>
-        <Slice
+        <this.props.SliceComponent
           slice={slice}
           pathFunction={makeSlicePath}
           style={sliceStyle}
         />
-        <SliceLabel
+        <this.props.SliceLabelComponent
           labelComponent={this.props.labelComponent}
           style={style.labels}
           positionFunction={labelPosition.centroid}

--- a/test/client/spec/components/victory-pie.spec.jsx
+++ b/test/client/spec/components/victory-pie.spec.jsx
@@ -7,6 +7,8 @@ import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
 import VictoryPie from "src/components/victory-pie";
+import Slice from "src/components/slice";
+
 // Use `TestUtils` to inject into DOM, simulate events, etc.
 // See: https://facebook.github.io/react/docs/test-utils.html
 import TestUtils from "react-addons-test-utils";
@@ -23,6 +25,34 @@ describe("components/victory-pie", () => {
   describe("default component rendering", () => {
     before(() => {
       renderedComponent = TestUtils.renderIntoDocument(<VictoryPie/>);
+    });
+
+    it("renders an svg with the correct width and height", () => {
+      const svg = getElement(renderedComponent, "svg");
+      // default width and height
+      expect(svg.style.width).to.equal(`${VictoryPie.defaultProps.width}px`);
+      expect(svg.style.height).to.equal(`${VictoryPie.defaultProps.height}px`);
+    });
+  });
+
+  describe("rendering with an injected Stateless Function Component", () => {
+    before(() => {
+      const MySlice = (props) => <Slice {...props} />;
+      renderedComponent = TestUtils.renderIntoDocument(<VictoryPie Slice={MySlice} />);
+    });
+
+    it("renders an svg with the correct width and height", () => {
+      const svg = getElement(renderedComponent, "svg");
+      // default width and height
+      expect(svg.style.width).to.equal(`${VictoryPie.defaultProps.width}px`);
+      expect(svg.style.height).to.equal(`${VictoryPie.defaultProps.height}px`);
+    });
+  });
+
+  describe("rendering with a injected factories", () => {
+    before(() => {
+      const myFactory = React.createFactory(Slice);
+      renderedComponent = TestUtils.renderIntoDocument(<VictoryPie Slice={myFactory} />);
     });
 
     it("renders an svg with the correct width and height", () => {


### PR DESCRIPTION
Please consider this humble proposal. I believe it contributes to a simple design to help enable "general interactivity" as in https://github.com/FormidableLabs/victory/issues/111

The goal behind this design change is to enable the use of the dependency injection pattern to enhance the functionality of ```Slice``` and ```SliceLabel``` when used within a ```VictoryPie``` component.

A user of victory-bar is able to, for example, replace ```VictoryPie```'s implementation of ```Slice``` with a  decorated version of ```Slice``` to wire up interactivity. See my trivial addition to demo/demo.jsx for an example of this in use!