### PR TITLE
update for naming change in victory-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "lodash": "^3.10.1",
     "radium": "^0.16.2",
     "victory-animation": "^0.0.13",
-    "victory-label": "^1.0.0",
-    "victory-util": "^4.0.0"
+    "victory-label": "^1.0.1",
+    "victory-util": "^5.0.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "~0.2.1",

--- a/src/components/slice-label.jsx
+++ b/src/components/slice-label.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import Radium from "radium";
-import { Chart } from "victory-util";
+import { Helpers } from "victory-util";
 import merge from "lodash/object/merge";
 import assign from "lodash/object/assign";
 import {VictoryLabel} from "victory-label";
@@ -16,7 +16,7 @@ export default class SliceLabel extends React.Component {
 
   renderLabelComponent(props, position, label) {
     const component = props.labelComponent;
-    const style = Chart.evaluateStyle(
+    const style = Helpers.evaluateStyle(
       merge({padding: 0}, props.style, component.props.style),
       this.data
     );
@@ -33,7 +33,7 @@ export default class SliceLabel extends React.Component {
   }
 
   renderVictoryLabel(props, position, label) {
-    const style = Chart.evaluateStyle(
+    const style = Helpers.evaluateStyle(
       assign({padding: 0}, props.style),
       props.slice.data
     );
@@ -54,7 +54,7 @@ export default class SliceLabel extends React.Component {
     const data = props.slice.data;
     const dataLabel = data.xName ? `${data.xName}` : `${data.x}`;
     const label = data.label ?
-    `${Chart.evaluateProp(data.label, data)}` : dataLabel;
+    `${Helpers.evaluateProp(data.label, data)}` : dataLabel;
     return props.labelComponent ?
       this.renderLabelComponent(props, position, label) :
       this.renderVictoryLabel(props, position, label);

--- a/src/components/slice.jsx
+++ b/src/components/slice.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import Radium from "radium";
-import { Chart } from "victory-util";
+import { Helpers } from "victory-util";
 import merge from "lodash/object/merge";
 import omit from "lodash/object/omit";
 
@@ -14,7 +14,7 @@ export default class Slice extends React.Component {
 
   renderSlice(props) {
     const dataStyles = omit(props.slice.data, ["x", "y", "label"]);
-    const style = Chart.evaluateStyle(merge({}, props.style, dataStyles), props.slice.data);
+    const style = Helpers.evaluateStyle(merge({}, props.style, dataStyles), props.slice.data);
     return (
       <path
         d={props.pathFunction(props.slice)}

--- a/src/components/victory-pie.jsx
+++ b/src/components/victory-pie.jsx
@@ -5,7 +5,7 @@ import isArray from "lodash/lang/isArray";
 import merge from "lodash/object/merge";
 import assign from "lodash/object/assign";
 import pick from "lodash/object/pick";
-import { PropTypes as CustomPropTypes, Data, Domain, Style, Chart } from "victory-util";
+import { PropTypes as CustomPropTypes, Helpers, Style } from "victory-util";
 import Slice from "./slice";
 import SliceLabel from "./slice-label";
 import {VictoryAnimation} from "victory-animation";
@@ -219,8 +219,6 @@ export default class VictoryPie extends React.Component {
     y: "y"
   };
 
-  static getDomain = Domain.getDomain.bind(Domain);
-
   renderSlice(slice, index, calculatedProps) {
     const {style, colorScale, makeSlicePath, labelPosition} = calculatedProps;
     const fill = colorScale[index % colorScale.length];
@@ -244,11 +242,7 @@ export default class VictoryPie extends React.Component {
 
   renderData(props, calculatedProps) {
     const {style, radius} = calculatedProps;
-    const data = Data.getData(props);
-    const domain = {
-      x: Domain.getDomain(props, "x"),
-      y: Domain.getDomain(props, "y")
-    };
+    const data = Helpers.getData(props);
     const labelPosition = getLabelPosition(props, style, radius);
     const colorScale = isArray(props.colorScale) ?
       props.colorScale : Style.getColorScale(props.colorScale);
@@ -257,7 +251,7 @@ export default class VictoryPie extends React.Component {
       .innerRadius(this.props.innerRadius);
 
     calculatedProps = assign(calculatedProps,
-      {data, domain, colorScale, makeSlicePath, labelPosition}
+      {data, colorScale, makeSlicePath, labelPosition}
     );
 
     const pie = d3Shape.pie()
@@ -291,8 +285,8 @@ export default class VictoryPie extends React.Component {
       );
     }
 
-    const style = Chart.getStyles(this.props, defaultStyles);
-    const padding = Chart.getPadding(this.props);
+    const style = Helpers.getStyles(this.props, defaultStyles);
+    const padding = Helpers.getPadding(this.props);
     const radius = getRadius(this.props, padding);
     const parentStyle = style.parent;
     const xOffset = radius + padding.left;


### PR DESCRIPTION
cc/ @coopy 

this PR updates `victory-pie` to use the new `Helpers` namespace in `victory-util`. 

Merge after https://github.com/FormidableLabs/victory-util/pull/26 and https://github.com/FormidableLabs/victory-label/pull/38
