### PR TITLE
Add `npm start` script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,35 @@
 VictoryPie
 =============
 
-`VictoryPie` draws an SVG pie or donut chart with [React](https://github.com/facebook/react). Styles and data can be customized by passing in your own values as properties to the component. Data changes are animated with [victory-animation](https://github.com/FormidableLabs/victory-animation).
+`VictoryPie` draws an SVG pie or donut chart with [React][]. Styles and data can be customized by passing in your own values as properties to the component. Data changes are animated with [victory-animation][].
 
-API Documentation
------------------
-Detailed documentation and interactive examples can be found at http://victory.formidable.com/docs/victory-pie
-
-IMPORTANT
-=========
-
-This project is in a pre-release state. We're hard at work fixing bugs and improving the API. Be prepared for breaking changes!
-
+## API Documentation
+Detailed documentation and interactive examples can be found at http://victory.formidable.com/docs/victory-pie.
 
 ## Development
 
-Please see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md)
+```sh
+# Run the demo app server
+$ npm start
+
+# Open the demo app
+$ open http://localhost:3000
+
+# Run tests
+$ npm test
+```
+
+For more on the development environment, see [DEVELOPMENT](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/DEVELOPMENT.md) in the project builder archetype.
 
 ## Contributing
 
-Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md)
+Please see [CONTRIBUTING](https://github.com/FormidableLabs/builder-victory-component/blob/master/dev/CONTRIBUTING.md) in the project builder archetype.
 
+## _IMPORTANT_
+
+This project is in a pre-release state. We're hard at work fixing bugs and improving the API. Be prepared for breaking changes!
+
+[React]: https://github.com/facebook/react
 [trav_img]: https://api.travis-ci.org/FormidableLabs/victory-pie.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/victory-pie
+[victory-animation]: https://github.com/FormidableLabs/victory-core/blob/master/src/victory-animation/victory-animation.jsx

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -49,17 +49,24 @@ export default class App extends React.Component {
     };
   }
 
-  componentWillMount() {
-    window.setInterval(() => {
+  componentDidMount() {
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setStateInterval = window.setInterval(() => {
       this.setState({
         data: getData()
       });
-    }, 3000);
+    }, 2000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
   }
 
   render() {
     return (
       <div>
+        <h1>VictoryPie Demo</h1>
+
         <VictoryPie style={this.state.style}/>
 
         <VictoryPie
@@ -79,7 +86,7 @@ export default class App extends React.Component {
           }}
         />
 
-        <VictoryPie style={this.state.style} endAngle={90} startAngle={-90}/>
+        <VictoryPie style={this.state.style} startAngle={-90} endAngle={90} />
 
         <VictoryPie
           style={this.state.style}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
+    "start": "builder run hot",
     "test": "builder run npm:test",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
-    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\"",
-    "test": "builder run npm:test"
+    "test": "builder run npm:test",
+    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {
-    "builder": "~2.4.0",
     "builder-victory-component": "~0.2.1",
+    "builder": "~2.4.0",
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",
     "victory-core": "^0.0.3"
@@ -34,7 +34,8 @@
     "react": "0.14.x",
     "react-addons-test-utils": "0.14.x",
     "react-dom": "0.14.x",
-    "sinon": "^1.15.4",
-    "sinon-chai": "^2.8.0"
+    "react": "0.14.x",
+    "sinon-chai": "^2.8.0",
+    "sinon": "^1.15.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
     "start": "builder run hot",
-    "test": "builder run npm:test",
+    "test": "builder run check",
     "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\""
   },
   "dependencies": {


### PR DESCRIPTION
I've added standard npm scripts and updated the README to have the minimum needed to get started on development.

- `npm start` runs `builder run hot`
- `npm test` runs `builder run check`

I've also fixed the demo app to clear the interval when the component unmounts.

/cc @tptee @boygirl 