### PR TITLE
Remove Radium

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -1,8 +1,7 @@
 /*global window:false*/
 import _ from "lodash";
 import React from "react";
-import Radium from "radium";
-import {VictoryPie} from "../src/index";
+import { VictoryPie } from "../src/index";
 
 const rand = () => Math.max(Math.floor(Math.random() * 10000), 1000);
 
@@ -18,7 +17,6 @@ const getData = () => {
   ];
 };
 
-@Radium
 export default class App extends React.Component {
 
   constructor(props) {

--- a/package.json
+++ b/package.json
@@ -24,15 +24,13 @@
     "builder-victory-component": "~0.2.1",
     "d3-shape": "^0.2.0",
     "lodash": "^3.10.1",
-    "radium": "^0.16.2",
-    "victory-animation": "^0.0.13",
-    "victory-label": "^1.0.1",
-    "victory-util": "^5.0.0"
+    "victory-core": "^0.0.3"
   },
   "devDependencies": {
     "builder-victory-component-dev": "~0.2.1",
     "chai": "^3.2.0",
     "mocha": "^2.2.5",
+    "radium": "^0.16.2",
     "react": "0.14.x",
     "react-addons-test-utils": "0.14.x",
     "react-dom": "0.14.x",

--- a/src/components/slice-label.jsx
+++ b/src/components/slice-label.jsx
@@ -1,11 +1,8 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
-import { Helpers } from "victory-util";
+import { Helpers, VictoryLabel } from "victory-core";
 import merge from "lodash/object/merge";
 import assign from "lodash/object/assign";
-import {VictoryLabel} from "victory-label";
 
-@Radium
 export default class SliceLabel extends React.Component {
   static propTypes = {
     labelComponent: PropTypes.any,

--- a/src/components/slice.jsx
+++ b/src/components/slice.jsx
@@ -1,10 +1,8 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
-import { Helpers } from "victory-util";
+import { Helpers } from "victory-core";
 import merge from "lodash/object/merge";
 import omit from "lodash/object/omit";
 
-@Radium
 export default class Slice extends React.Component {
   static propTypes = {
     slice: PropTypes.object,

--- a/src/components/victory-pie.jsx
+++ b/src/components/victory-pie.jsx
@@ -1,14 +1,17 @@
 import React, { PropTypes } from "react";
-import Radium from "radium";
 import d3Shape from "d3-shape";
 import isArray from "lodash/lang/isArray";
 import merge from "lodash/object/merge";
 import assign from "lodash/object/assign";
 import pick from "lodash/object/pick";
-import { PropTypes as CustomPropTypes, Helpers, Style } from "victory-util";
+import {
+  PropTypes as CustomPropTypes,
+  Helpers,
+  Style,
+  VictoryAnimation
+} from "victory-core";
 import Slice from "./slice";
 import SliceLabel from "./slice-label";
-import {VictoryAnimation} from "victory-animation";
 
 const defaultStyles = {
   data: {
@@ -48,7 +51,6 @@ const getLabelPosition = function (props, style, radius) {
     .innerRadius(innerRadius);
 };
 
-@Radium
 export default class VictoryPie extends React.Component {
   static propTypes = {
     /**
@@ -285,7 +287,12 @@ export default class VictoryPie extends React.Component {
       );
     }
 
-    const style = Helpers.getStyles(this.props, defaultStyles);
+    const style = Helpers.getStyles(
+      this.props.style,
+      defaultStyles,
+      this.props.height,
+      this.props.width)
+    ;
     const padding = Helpers.getPadding(this.props);
     const radius = getRadius(this.props, padding);
     const parentStyle = style.parent;


### PR DESCRIPTION
Following the same pattern as before.  Radium is present in devDeps for demo purposes, removed elsewhere.  Replaced `victory-*` with `victory-util`.  cc @boygirl