### PR TITLE
Adds dataComponent prop to Pie

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -2,6 +2,7 @@
 import _ from "lodash";
 import React from "react";
 import { VictoryPie } from "../src/index";
+import Slice from "../src/components/slice";
 
 const rand = () => Math.max(Math.floor(Math.random() * 10000), 1000);
 
@@ -16,6 +17,48 @@ const getData = () => {
     { x: "≥65", y: rand() }
   ];
 };
+
+class BorderLabelSlice extends React.Component {
+  static propTypes = {
+    ...Slice.propTypes,
+    index: React.PropTypes.number
+  };
+
+  render() {
+    const {index} = this.props;
+
+    return (
+      <g key={`slice-and-label-${index}`}>
+        {this.renderSlice(this.props)}
+        {this.renderLabel(this.props)}
+      </g>
+    );
+  }
+
+  renderSlice(props) {
+    return <Slice {...props} />;
+  }
+
+  renderLabel(props) {
+    const {pathFunction, datum, slice, index} = props;
+
+    const path = pathFunction({...slice, endAngle: slice.startAngle});
+
+    const pathId = `textPath-path-${index}`;
+
+    return (
+      <g>
+        <path id={pathId} d={path} />
+        <text>
+          <textPath xlinkHref={`#${pathId}`}>
+            {datum.label || datum.xName || datum.x}
+          </textPath>
+        </text>
+      </g>
+    );
+  }
+
+}
 
 export default class App extends React.Component {
 
@@ -98,6 +141,15 @@ export default class App extends React.Component {
         />
 
         <VictoryPie style={this.state.style} startAngle={-90} endAngle={90} />
+
+        <VictoryPie
+          style={{...this.state.style, labels: {fontSize: 0}}}
+          data={this.state.data}
+          innerRadius={100}
+          animate={{velocity: 0.03}}
+          colorScale={this.state.colorScale}
+          dataComponent={<BorderLabelSlice />}
+        />
 
         <VictoryPie
           style={this.state.style}

--- a/src/components/victory-pie.jsx
+++ b/src/components/victory-pie.jsx
@@ -92,6 +92,16 @@ export default class VictoryPie extends React.Component {
      */
     data: PropTypes.array,
     /**
+     * The dataComponent prop takes an entire, HTML-complete data component which will be used to
+     * create slices for each datum in the pie chart. The new element created from the passed
+     * dataComponent will have the property datum set by the pie chart for the point it renders;
+     * properties style and pathFunction calculated by VictoryPie; an index property set
+     * corresponding to the location of the datum in the data provided to the pie; events bound to
+     * the VictoryPie; and the d3 compatible slice object.
+     * If a dataComponent is not provided, VictoryPie's Slice component will be used.
+     */
+    dataComponent: PropTypes.element,
+    /**
      * The overall end angle of the pie in degrees. This prop is used in conjunction with
      * startAngle to create a pie that spans only a segment of a circle.
      */
@@ -240,7 +250,8 @@ export default class VictoryPie extends React.Component {
     standalone: true,
     width: 400,
     x: "x",
-    y: "y"
+    y: "y",
+    dataComponent: <Slice />
   };
 
   componentWillMount() {
@@ -259,17 +270,19 @@ export default class VictoryPie extends React.Component {
     const fill = colorScale[index % colorScale.length];
     const sliceStyle = defaults({}, {fill}, style.data);
     const getBoundEvents = Helpers.getEvents.bind(this);
+    const sliceComponent = React.cloneElement(this.props.dataComponent, {
+      index,
+      events: getBoundEvents(this.props.events.data, "data"),
+      slice,
+      pathFunction: makeSlicePath,
+      style: sliceStyle,
+      datum: slice.data,
+      ...this.state.dataState[index]
+    });
+
     return (
       <g key={index}>
-        <Slice
-          index={index}
-          events={getBoundEvents(this.props.events.data, "data")}
-          slice={slice}
-          pathFunction={makeSlicePath}
-          style={sliceStyle}
-          datum={slice.data}
-          {...this.state.dataState[index]}
-        />
+        {sliceComponent}
         <SliceLabel
           index={index}
           events={getBoundEvents(this.props.events.labels, "labels")}

--- a/test/client/spec/components/victory-pie.spec.jsx
+++ b/test/client/spec/components/victory-pie.spec.jsx
@@ -9,6 +9,10 @@ import { shallow, mount } from "enzyme";
 import VictoryPie from "src/components/victory-pie";
 import Slice from "src/components/slice";
 
+class PizzaSlice extends React.Component {
+  render() {}
+}
+
 describe("components/victory-pie", () => {
   describe("default component rendering", () => {
     it("renders an svg with the correct width and height", () => {
@@ -22,6 +26,18 @@ describe("components/victory-pie", () => {
   });
 
   describe("rendering data", () => {
+    it("renders dataComponents for {x, y} shaped data (default)", () => {
+      const data = _.range(5).map((i) => ({x: i, y: i}));
+      const wrapper = shallow(
+        <VictoryPie
+          data={data}
+          dataComponent={<PizzaSlice />}
+        />
+      );
+      const slices = wrapper.find(PizzaSlice);
+      expect(slices.length).to.equal(5);
+    });
+
     it("renders points for {x, y} shaped data (default)", () => {
       const data = _.range(5).map((i) => ({x: i, y: i}));
       const wrapper = shallow(<VictoryPie data={data}/>);


### PR DESCRIPTION
Includes a (single) shallow test to assert the type of node matches that
provided in the props.

#### Todo
- [x] an example in the victory pie demos

Replaces FormidableLabs/victory-pie#50