### PR TITLE
add cornerRadius prop

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -226,6 +226,18 @@ export default class App extends React.Component {
             animate={{duration: 2000}}
             colorScale="qualitative"
           />
+
+          <VictoryPie style={this.state.style}
+            data={range(0, 2).map((i) => [i, Math.random()])}
+            x={0}
+            y={1}
+            colorScale={["#FF2800", "#FFF"]}
+            labels={[""]}
+            cornerRadius={20}
+            startAngle={-6}
+            animate={{duration: 2000}}
+            innerRadius={140}
+          />
         </div>
       </div>
     );

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -59,6 +59,7 @@ export default {
     const layoutFunction = this.getSliceFunction(props);
     const slices = layoutFunction(data);
     const pathFunction = d3Shape.arc()
+      .cornerRadius(props.cornerRadius)
       .outerRadius(radius)
       .innerRadius(props.innerRadius);
     return {style, colors, padding, radius, data, slices, labelPosition, pathFunction};

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -168,6 +168,10 @@ export default class VictoryPie extends React.Component {
      */
     innerRadius: CustomPropTypes.nonNegative,
     /**
+     * Set the cornerRadius for every dataComponent (Slice by default) within VictoryPie
+     */
+    cornerRadius: CustomPropTypes.nonNegative,
+    /**
      * The labelComponent prop takes in an entire label component which will be used
      * to create labels for each slice in the pie chart. The new element created from
      * the passed labelComponent will be supplied with the following properties:
@@ -281,6 +285,7 @@ export default class VictoryPie extends React.Component {
     endAngle: 360,
     height: 400,
     innerRadius: 0,
+    cornerRadius: 0,
     padAngle: 0,
     padding: 30,
     colorScale: [
@@ -364,7 +369,7 @@ export default class VictoryPie extends React.Component {
     // and (2) `animate` set to null so we don't recurse forever.
     if (this.props.animate) {
       const whitelist = [
-        "data", "endAngle", "height", "innerRadius", "padAngle", "padding",
+        "data", "endAngle", "height", "innerRadius", "cornerRadius", "padAngle", "padding",
         "colorScale", "startAngle", "style", "width"
       ];
       return (


### PR DESCRIPTION
This adds the ability to pass cornerRadius prop to VictoryPie, and get a result similar to this: https://www.npmjs.com/package/d3-shape#arc_cornerRadius