### PR TITLE
bumping up font size for pie labels

### DIFF
--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -22,7 +22,7 @@ const defaultStyles = {
     strokeWidth: 0,
     stroke: "transparent",
     fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-    fontSize: 11,
+    fontSize: 13,
     textAnchor: "middle"
   }
 };

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -22,7 +22,7 @@ const defaultStyles = {
     strokeWidth: 0,
     stroke: "transparent",
     fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-    fontSize: 10,
+    fontSize: 11,
     textAnchor: "middle"
   }
 };


### PR DESCRIPTION
similar to default font increases in victory chart, this increases the default font size of labels for victory pie for better readability on smaller charts. @boygirl 