### PR TITLE
add theme support to victorypie and do some grayscale demos

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -254,7 +254,6 @@ export default class App extends React.Component {
             theme={VictoryTheme.grayscale}
             style={{parent: {maxWidth: "40%"}}}
             animate={{duration: 2000}}
-            // colorScale="qualitative"
           />
 
           <VictoryPie style={this.state.style}

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4,7 +4,7 @@ import React from "react";
 import { VictoryPie } from "../src/index";
 import Slice from "../src/components/slice";
 import {
-  VictoryContainer, VictoryThemeGrayscale
+  VictoryContainer, VictoryTheme
 } from "victory-core";
 
 class BorderLabelSlice extends React.Component {
@@ -149,7 +149,7 @@ export default class App extends React.Component {
 
           <VictoryPie
             style={{parent: {maxWidth: "40%"}}}
-            theme={VictoryThemeGrayscale}
+            theme={VictoryTheme.grayscale}
             labels={() => "click me!"}
             events={[{
               target: "data",
@@ -231,7 +231,7 @@ export default class App extends React.Component {
             data={range(0, 6).map((i) => [i, Math.random()])}
             x={0}
             y={1}
-            theme={VictoryThemeGrayscale}
+            theme={VictoryTheme.grayscale}
             style={{parent: {maxWidth: "40%"}}}
             animate={{duration: 2000}}
             // colorScale="qualitative"

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4,7 +4,7 @@ import React from "react";
 import { VictoryPie } from "../src/index";
 import Slice from "../src/components/slice";
 import {
-  VictoryContainer
+  VictoryContainer, VictoryThemeGrayscale
 } from "victory-core";
 
 class BorderLabelSlice extends React.Component {
@@ -148,7 +148,8 @@ export default class App extends React.Component {
           />
 
           <VictoryPie
-            style={this.state.style}
+            style={{parent: {maxWidth: "40%"}}}
+            theme={VictoryThemeGrayscale}
             labels={() => "click me!"}
             events={[{
               target: "data",
@@ -230,9 +231,10 @@ export default class App extends React.Component {
             data={range(0, 6).map((i) => [i, Math.random()])}
             x={0}
             y={1}
-            style={this.state.style}
+            theme={VictoryThemeGrayscale}
+            style={{parent: {maxWidth: "40%"}}}
             animate={{duration: 2000}}
-            colorScale="qualitative"
+            // colorScale="qualitative"
           />
 
           <VictoryPie style={this.state.style}

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,7 @@
   <title>Demo</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link href='https://fonts.googleapis.com/css?family=Poppins' rel='stylesheet' type='text/css'>
 </head>
 <body>
   <!--[if lt IE 8]>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "builder": "~2.9.1",
     "d3-shape": "^0.6.0",
     "lodash": "^4.12.0",
-    "victory-core": "^4.1.1"
+    "victory-core": "^4.2.0"
   },
   "devDependencies": {
     "@kadira/storybook": "^1.25.0",

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -64,7 +64,7 @@ export default {
     : fallbackProps.style;
     const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
     const getColorScale = () => {
-      return theme ? theme.colorScale : fallbackProps.colorScale;
+      return theme ? theme.props.colorScale : fallbackProps.colorScale;
     };
     const colorScale = props.colorScale || getColorScale();
     const colors = Array.isArray(colorScale) ?

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -13,10 +13,7 @@ export default {
   },
 
   getBaseProps(props, fallbackProps) {
-    const defaultStyles = props.theme && props.theme.pie ? props.theme.pie.style
-    : fallbackProps.styles;
-    const calculatedValues = this.getCalculatedValues(props, defaultStyles,
-      fallbackProps.colorScale);
+    const calculatedValues = this.getCalculatedValues(props, fallbackProps);
     const { slices, style, pathFunction, colors, labelPosition } = calculatedValues;
     const { width, height } = props;
     const parentProps = {slices, pathFunction, width, height, style: style.parent};
@@ -61,12 +58,14 @@ export default {
     }, {parent: parentProps});
   },
 
-  getCalculatedValues(props, defaultStyles, defaultColorScale) {
-    const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
-    const propsFallbacks = props.colorScale || defaultColorScale;
+  getCalculatedValues(props, fallbackProps) {
+    const styleObject = props.theme && props.theme.pie ? props.theme.pie.style
+    : fallbackProps.style;
+    const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
+    const propsFallbacks = props.colorScale || fallbackProps.colorScale;
     const theme = props.theme && props.theme.pie;
     const colorScale = theme ?
-    props.colorScale || props.theme.pie.props.colorScale || defaultColorScale
+    props.colorScale || props.theme.pie.props.colorScale || fallbackProps.colorScale
     : propsFallbacks;
     const colors = Array.isArray(colorScale) ?
     colorScale : Style.getColorScale(colorScale);

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -59,14 +59,14 @@ export default {
   },
 
   getCalculatedValues(props, fallbackProps) {
-    const styleObject = props.theme && props.theme.pie ? props.theme.pie.style
+    const theme = props.theme && props.theme.pie;
+    const styleObject = theme ? props.theme.pie.style
     : fallbackProps.style;
     const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
-    const propsFallbacks = props.colorScale || fallbackProps.colorScale;
-    const theme = props.theme && props.theme.pie;
-    const colorScale = theme ?
-    props.colorScale || props.theme.pie.props.colorScale || fallbackProps.colorScale
-    : propsFallbacks;
+    const getColorScale = () => {
+      return theme ? theme.colorScale : fallbackProps.colorScale;
+    };
+    const colorScale = props.colorScale || getColorScale();
     const colors = Array.isArray(colorScale) ?
     colorScale : Style.getColorScale(colorScale);
     const padding = Helpers.getPadding(props);

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -64,7 +64,6 @@ export default {
     const colorScale = props.theme && props.theme.pie ?
     props.colorScale || props.theme.pie.props.colorScale || defaultColorScale
     : props.colorScale || defaultColorScale;
-    console.log(colorScale);
     const colors = Array.isArray(colorScale) ?
     colorScale : Style.getColorScale(colorScale);
     const padding = Helpers.getPadding(props);

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -13,6 +13,7 @@ export default {
   },
 
   getBaseProps(props, defaultStyles) {
+    defaultStyles = props.theme && props.theme.pie ? props.theme.pie : defaultStyles;
     const calculatedValues = this.getCalculatedValues(props, defaultStyles);
     const { slices, style, pathFunction, colors, labelPosition } = calculatedValues;
     return slices.reduce((memo, slice, index) => {
@@ -58,8 +59,10 @@ export default {
 
   getCalculatedValues(props, defaultStyles) {
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
-    const colors = Array.isArray(props.colorScale) ?
-      props.colorScale : Style.getColorScale(props.colorScale);
+    const colorScale = props.theme && props.theme.pie ? props.theme.pie.colorScale
+    : props.colorScale;
+    const colors = Array.isArray(colorScale) ?
+    colorScale : Style.getColorScale(colorScale);
     const padding = Helpers.getPadding(props);
     const radius = this.getRadius(props, padding);
     const data = Events.addEventKeys(props, Helpers.getData(props));

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -12,9 +12,11 @@ export default {
     }
   },
 
-  getBaseProps(props, defaultStyles, defaultColorScale) {
-    defaultStyles = props.theme && props.theme.pie ? props.theme.pie.style : defaultStyles;
-    const calculatedValues = this.getCalculatedValues(props, defaultStyles, defaultColorScale);
+  getBaseProps(props, fallbackProps) {
+    const defaultStyles = props.theme && props.theme.pie ? props.theme.pie.style
+    : fallbackProps.styles;
+    const calculatedValues = this.getCalculatedValues(props, defaultStyles,
+      fallbackProps.colorScale);
     const { slices, style, pathFunction, colors, labelPosition } = calculatedValues;
     const { width, height } = props;
     const parentProps = {slices, pathFunction, width, height, style: style.parent};
@@ -61,9 +63,11 @@ export default {
 
   getCalculatedValues(props, defaultStyles, defaultColorScale) {
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
-    const colorScale = props.theme && props.theme.pie ?
+    const propsFallbacks = props.colorScale || defaultColorScale;
+    const theme = props.theme && props.theme.pie;
+    const colorScale = theme ?
     props.colorScale || props.theme.pie.props.colorScale || defaultColorScale
-    : props.colorScale || defaultColorScale;
+    : propsFallbacks;
     const colors = Array.isArray(colorScale) ?
     colorScale : Style.getColorScale(colorScale);
     const padding = Helpers.getPadding(props);

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -12,9 +12,9 @@ export default {
     }
   },
 
-  getBaseProps(props, defaultStyles) {
-    defaultStyles = props.theme && props.theme.pie ? props.theme.pie : defaultStyles;
-    const calculatedValues = this.getCalculatedValues(props, defaultStyles);
+  getBaseProps(props, defaultStyles, defaultColorScale) {
+    defaultStyles = props.theme && props.theme.pie ? props.theme.pie.style : defaultStyles;
+    const calculatedValues = this.getCalculatedValues(props, defaultStyles, defaultColorScale);
     const { slices, style, pathFunction, colors, labelPosition } = calculatedValues;
     return slices.reduce((memo, slice, index) => {
       const datum = slice.data;
@@ -57,10 +57,12 @@ export default {
     }, {});
   },
 
-  getCalculatedValues(props, defaultStyles) {
+  getCalculatedValues(props, defaultStyles, defaultColorScale) {
     const style = Helpers.getStyles(props.style, defaultStyles, "auto", "100%");
-    const colorScale = props.theme && props.theme.pie ? props.theme.pie.colorScale
-    : props.colorScale;
+    const colorScale = props.theme && props.theme.pie ?
+    props.colorScale || props.theme.pie.props.colorScale || defaultColorScale
+    : props.colorScale || defaultColorScale;
+    console.log(colorScale);
     const colors = Array.isArray(colorScale) ?
     colorScale : Style.getColorScale(colorScale);
     const padding = Helpers.getPadding(props);

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -27,6 +27,16 @@ const defaultStyles = {
   }
 };
 
+const defaultColorScale = [
+  "#75C776",
+  "#39B6C5",
+  "#78CCC4",
+  "#62C3A4",
+  "#64A8D1",
+  "#8C95C8",
+  "#3BAF74"
+];
+
 export default class VictoryPie extends React.Component {
   static defaultTransitions = {
     onExit: {
@@ -312,15 +322,6 @@ export default class VictoryPie extends React.Component {
     cornerRadius: 0,
     padAngle: 0,
     padding: 30,
-    colorScale: [
-      "#75C776",
-      "#39B6C5",
-      "#78CCC4",
-      "#62C3A4",
-      "#64A8D1",
-      "#8C95C8",
-      "#3BAF74"
-    ],
     startAngle: 0,
     standalone: true,
     width: 400,
@@ -331,7 +332,8 @@ export default class VictoryPie extends React.Component {
     containerComponent: <VictoryContainer/>
   };
 
-  static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers), defaultStyles);
+  static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers),
+    defaultStyles, defaultColorScale);
 
   constructor() {
     super();
@@ -342,11 +344,13 @@ export default class VictoryPie extends React.Component {
   }
 
   componentWillMount() {
-    this.baseProps = PieHelpers.getBaseProps(this.props, defaultStyles);
+    this.baseProps = PieHelpers.getBaseProps(this.props,
+      defaultStyles, defaultColorScale);
   }
 
   componentWillReceiveProps(newProps) {
-    this.baseProps = PieHelpers.getBaseProps(newProps, defaultStyles);
+    this.baseProps = PieHelpers.getBaseProps(newProps,
+      defaultStyles, defaultColorScale);
   }
 
   renderData(props) {
@@ -404,7 +408,7 @@ export default class VictoryPie extends React.Component {
       );
     }
 
-    const styleObject = this.props.theme && this.props.theme.pie ? this.props.theme.pie
+    const styleObject = this.props.theme && this.props.theme.pie ? this.props.theme.pie.style
     : defaultStyles;
     const calculatedProps = PieHelpers.getCalculatedValues(this.props, styleObject);
     const { style, padding, radius } = calculatedProps;

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -288,7 +288,14 @@ export default class VictoryPie extends React.Component {
      * @example <VictoryContainer title="Chart of Dog Breeds" desc="This chart shows how
      * popular each dog breed is by percentage in Seattle." />
      */
-    containerComponent: PropTypes.element
+    containerComponent: PropTypes.element,
+    /**
+    * The theme prop takes a style object with nested data, labels, and parent objects.
+    * You can create this object yourself, or you can use a theme provided by Victory.
+    * @example theme={Grayscale}
+    * http://www.github.com/FormidableLabs/victory-core/tree/master/src/victory-theme/grayscale.js
+    */
+    theme: PropTypes.object
   };
 
   static defaultProps = {
@@ -397,7 +404,9 @@ export default class VictoryPie extends React.Component {
       );
     }
 
-    const calculatedProps = PieHelpers.getCalculatedValues(this.props, defaultStyles);
+    const styleObject = this.props.theme && this.props.theme.pie ? this.props.theme.pie
+    : defaultStyles;
+    const calculatedProps = PieHelpers.getCalculatedValues(this.props, styleObject);
     const { style, padding, radius } = calculatedProps;
     const xOffset = radius + padding.left;
     const yOffset = radius + padding.top;

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -10,33 +10,6 @@ import {
 import Slice from "./slice";
 import PieHelpers from "./helper-methods";
 
-// const defaultStyles = {
-//   data: {
-//     padding: 5,
-//     stroke: "white",
-//     strokeWidth: 1
-//   },
-//   labels: {
-//     padding: 10,
-//     fill: "black",
-//     strokeWidth: 0,
-//     stroke: "transparent",
-//     fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-//     fontSize: 13,
-//     textAnchor: "middle"
-//   }
-// };
-
-// const defaultColorScale = [
-//   "#75C776",
-//   "#39B6C5",
-//   "#78CCC4",
-//   "#62C3A4",
-//   "#64A8D1",
-//   "#8C95C8",
-//   "#3BAF74"
-// ];
-
 const fallbackProps = {
   styles: {
     data: {

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -11,7 +11,7 @@ import Slice from "./slice";
 import PieHelpers from "./helper-methods";
 
 const fallbackProps = {
-  styles: {
+  style: {
     data: {
       padding: 5,
       stroke: "white",
@@ -435,9 +435,7 @@ export default class VictoryPie extends React.Component {
       );
     }
 
-    const styleObject = this.props.theme && this.props.theme.pie ? this.props.theme.pie.style
-    : fallbackProps.styles;
-    const calculatedProps = PieHelpers.getCalculatedValues(this.props, styleObject);
+    const calculatedProps = PieHelpers.getCalculatedValues(this.props, fallbackProps);
     const { style, padding, radius } = calculatedProps;
     const xOffset = radius + padding.left;
     const yOffset = radius + padding.top;

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -10,32 +10,60 @@ import {
 import Slice from "./slice";
 import PieHelpers from "./helper-methods";
 
-const defaultStyles = {
-  data: {
-    padding: 5,
-    stroke: "white",
-    strokeWidth: 1
-  },
-  labels: {
-    padding: 10,
-    fill: "black",
-    strokeWidth: 0,
-    stroke: "transparent",
-    fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-    fontSize: 13,
-    textAnchor: "middle"
-  }
-};
+// const defaultStyles = {
+//   data: {
+//     padding: 5,
+//     stroke: "white",
+//     strokeWidth: 1
+//   },
+//   labels: {
+//     padding: 10,
+//     fill: "black",
+//     strokeWidth: 0,
+//     stroke: "transparent",
+//     fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
+//     fontSize: 13,
+//     textAnchor: "middle"
+//   }
+// };
 
-const defaultColorScale = [
-  "#75C776",
-  "#39B6C5",
-  "#78CCC4",
-  "#62C3A4",
-  "#64A8D1",
-  "#8C95C8",
-  "#3BAF74"
-];
+// const defaultColorScale = [
+//   "#75C776",
+//   "#39B6C5",
+//   "#78CCC4",
+//   "#62C3A4",
+//   "#64A8D1",
+//   "#8C95C8",
+//   "#3BAF74"
+// ];
+
+const fallbackProps = {
+  styles: {
+    data: {
+      padding: 5,
+      stroke: "white",
+      strokeWidth: 1
+    },
+    labels: {
+      padding: 10,
+      fill: "black",
+      strokeWidth: 0,
+      stroke: "transparent",
+      fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
+      fontSize: 13,
+      textAnchor: "middle"
+    }
+  },
+  colorScale: [
+    "#75C776",
+    "#39B6C5",
+    "#78CCC4",
+    "#62C3A4",
+    "#64A8D1",
+    "#8C95C8",
+    "#3BAF74"
+  ]
+};
 
 export default class VictoryPie extends React.Component {
   static defaultTransitions = {
@@ -332,8 +360,7 @@ export default class VictoryPie extends React.Component {
     containerComponent: <VictoryContainer/>
   };
 
-  static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers),
-    defaultStyles, defaultColorScale);
+  static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers), fallbackProps);
 
   constructor() {
     super();
@@ -353,7 +380,7 @@ export default class VictoryPie extends React.Component {
 
   setupEvents(props) {
     const { sharedEvents } = props;
-    this.baseProps = PieHelpers.getBaseProps(props, defaultStyles, defaultColorScale);
+    this.baseProps = PieHelpers.getBaseProps(props, fallbackProps);
     this.dataKeys = Object.keys(this.baseProps).filter((key) => key !== "parent");
     this.getSharedEventState = sharedEvents && isFunction(sharedEvents.getEventState) ?
       sharedEvents.getEventState : () => undefined;
@@ -436,7 +463,7 @@ export default class VictoryPie extends React.Component {
     }
 
     const styleObject = this.props.theme && this.props.theme.pie ? this.props.theme.pie.style
-    : defaultStyles;
+    : fallbackProps.styles;
     const calculatedProps = PieHelpers.getCalculatedValues(this.props, styleObject);
     const { style, padding, radius } = calculatedProps;
     const xOffset = radius + padding.left;


### PR DESCRIPTION
This PR adds theme support to Victory-Pie and adds some demos of the grayscale theme.

In reference to comments from https://github.com/FormidableLabs/victory-chart/pull/242 a link to the source code for grayscale in victory-core has been included in the props description as an example of a theme. (This link will be functional once https://github.com/FormidableLabs/victory-core/pull/71 has been merged).

@boygirl 