### PR TITLE
Parent events

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -163,8 +163,28 @@ export default class App extends React.Component {
                       }
                     }, {
                       target: "labels",
+                      eventKey: [0, 2, 4],
                       mutation: () => {
                         return {text: "hey"};
+                      }
+                    }
+                  ];
+                }
+              }
+            }]}
+          />
+
+          <VictoryPie
+            style={this.state.style}
+            events={[{
+              target: "parent",
+              eventHandlers: {
+                onClick: () => {
+                  return [
+                    {
+                      target: "labels",
+                      mutation: () => {
+                        return {text: "parent click"};
                       }
                     }
                   ];

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -239,7 +239,7 @@ export default class App extends React.Component {
             data={range(0, 2).map((i) => [i, Math.random()])}
             x={0}
             y={1}
-            colorScale={["#FF2800", "#FFF"]}
+            colorScale={["tomato", "orange"]}
             labels={[]}
             cornerRadius={20}
             startAngle={-6}

--- a/docs/ecology.md
+++ b/docs/ecology.md
@@ -153,7 +153,10 @@ Functional styles allow elements to determine their own styles based on data
 
 ### Events
 
-Use the `events` prop to attach events to specific elements in VictoryPie. The `events` prop takes an array of event objects, each of which is composed of a `target`, an `eventKey`, and `eventHandlers`. `target` may be any valid style namespace for a given component, so "data" and "labels" are all valid targets for VictoryPie events. The `eventKey` may optionally be used to select a single element by index rather than an entire set. The `eventHandlers` object should be given as an object whose keys are standard event names (i.e. `onClick`) and whose values are event callbacks. The return value of an event handler is used to modify elemnts. The return value should be given as an object or an array of objects with optional `eventKey` and `target` keys, and a `mutation` key whose value is a function. The `eventKey` and `target` keys will default to values corresponding to the element the event handler was attached to. The `mutation` function will be called with the calculated props for the individual selected element (_i.e._ a single bar), and the object returned from the mutation function will override the props of the selected element via object assignment. VictoryPie may also be used with the `VictorySharedEvents` wrapper.
+Use the `events` prop to attach events to specific elements in VictoryPie. The `events` prop takes an array of event objects, each of which is composed of a `target`, an `eventKey`, and `eventHandlers`. `target` may be any valid style namespace for a given component, so `parent`, `data` and `labels` are all valid targets for VictoryPie events. 
+
+
+The `eventKey` may optionally be used to select a single element by index rather than an entire set. The `eventHandlers` object should be given as an object whose keys are standard event names (i.e. `onClick`) and whose values are event callbacks. The return value of an event handler is used to modify elements. The return value should be given as an object or an array of objects with optional `eventKey` and `target` keys, and a `mutation` key whose value is a function. The `eventKey` and `target` keys will default to values corresponding to the element the event handler was attached to. The `mutation` function will be called with the calculated props for the individual selected element (_i.e._ a single bar), and the object returned from the mutation function will override the props of the selected element via object assignment. VictoryPie may also be used with the `VictorySharedEvents` wrapper.
 
 ``` playground
   <VictoryPie
@@ -176,8 +179,9 @@ Use the `events` prop to attach events to specific elements in VictoryPie. The `
               }
             }, {
               target: "labels",
+              eventKey: [1, 2, 3],
               mutation: () => {
-                return {text: "hey"};
+                return {text: "KITTEN"};
               }
             }
           ];

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "storybook": "start-storybook -p 3001"
   },
   "dependencies": {
-    "builder-victory-component": "^2.1.4",
+    "builder-victory-component": "^2.1.8",
     "builder": "~2.9.1",
     "d3-shape": "^0.6.0",
     "lodash": "^4.12.0",
-    "victory-core": "^3.0.0"
+    "victory-core": "^4.1.1"
   },
   "devDependencies": {
     "@kadira/storybook": "^1.25.0",
-    "builder-victory-component-dev": "^2.1.4",
+    "builder-victory-component-dev": "^2.1.8",
     "chai": "^3.2.0",
     "chai-enzyme": "0.4.1",
     "ecology": "^1.3.0",

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -15,6 +15,8 @@ export default {
   getBaseProps(props, defaultStyles) {
     const calculatedValues = this.getCalculatedValues(props, defaultStyles);
     const { slices, style, pathFunction, colors, labelPosition } = calculatedValues;
+    const { width, height } = props;
+    const parentProps = {slices, pathFunction, width, height, style: style.parent};
     return slices.reduce((memo, slice, index) => {
       const datum = slice.data;
       const eventKey = datum.eventKey;
@@ -53,7 +55,7 @@ export default {
         labels: labelProps
       };
       return memo;
-    }, {});
+    }, {parent: parentProps});
   },
 
   getCalculatedValues(props, defaultStyles) {

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -351,7 +351,9 @@ export default class VictoryPie extends React.Component {
   }
 
   renderData(props) {
-    const components = this.dataKeys.reduce((memo, key) => {
+    const sliceComponents = [];
+    const sliceLabelComponents = [];
+    this.dataKeys.forEach((key) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
         {key: `pie-${key}`},
@@ -360,10 +362,9 @@ export default class VictoryPie extends React.Component {
         this.baseProps[key].data,
         props.dataComponent.props
       );
-      const sliceComponent = React.cloneElement(props.dataComponent, Object.assign(
+      sliceComponents.push(React.cloneElement(props.dataComponent, Object.assign(
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
-      ));
-      memo.data = memo.data.concat(sliceComponent);
+      )));
 
       const labelProps = defaults(
         {key: `pie-label-${key}`},
@@ -374,23 +375,21 @@ export default class VictoryPie extends React.Component {
       );
       if (labelProps && labelProps.text) {
         const labelEvents = this.getEvents(props, "labels", key);
-        const labelComponent = React.cloneElement(props.labelComponent, Object.assign({
+        sliceLabelComponents.push(React.cloneElement(props.labelComponent, Object.assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)
-        }, labelProps));
-        memo.labels = memo.labels.concat(labelComponent);
+        }, labelProps)));
       }
-      return memo;
-    }, {data: [], labels: []});
+    });
 
-    if (components.labels.length > 0) {
+    if (sliceLabelComponents.length > 0) {
       return (
         <g key={`pie-group`}>
-          {components.data}
-          {components.labels}
+          {sliceComponents}
+          {sliceLabelComponents}
         </g>
       );
     }
-    return components.data;
+    return sliceComponents;
   }
 
   renderContainer(props, group) {

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -350,8 +350,8 @@ export default class VictoryPie extends React.Component {
       sharedEvents.getEventState : () => undefined;
   }
 
-  renderSlices(props) {
-    return this.dataKeys.map((key) => {
+  renderData(props) {
+    const components = this.dataKeys.reduce((memo, key) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
         {key: `pie-${key}`},
@@ -360,14 +360,11 @@ export default class VictoryPie extends React.Component {
         this.baseProps[key].data,
         props.dataComponent.props
       );
-      return React.cloneElement(props.dataComponent, Object.assign(
+      const sliceComponent = React.cloneElement(props.dataComponent, Object.assign(
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
-    });
-  }
+      memo.data = memo.data.concat(sliceComponent);
 
-  renderLabels(props) {
-    return this.dataKeys.reduce((memo, key) => {
       const labelProps = defaults(
         {key: `pie-label-${key}`},
         this.getEventState(key, "labels"),
@@ -380,24 +377,20 @@ export default class VictoryPie extends React.Component {
         const labelComponent = React.cloneElement(props.labelComponent, Object.assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)
         }, labelProps));
-        return memo.concat(labelComponent);
+        memo.labels = memo.labels.concat(labelComponent);
       }
       return memo;
-    }, []);
-  }
+    }, {data: [], labels: []});
 
-  renderData(props) {
-    const pie = this.renderSlices(props);
-    const pieLabels = this.renderLabels(props);
-    if (pieLabels.length > 0) {
+    if (components.labels.length > 0) {
       return (
         <g key={`pie-group`}>
-          {pie}
-          {pieLabels}
+          {components.data}
+          {components.labels}
         </g>
       );
     }
-    return pie;
+    return components.data;
   }
 
   renderContainer(props, group) {

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -129,7 +129,7 @@ export default class VictoryPie extends React.Component {
      *}}
      */
     events: PropTypes.arrayOf(PropTypes.shape({
-      target: PropTypes.oneOf(["data", "labels"]),
+      target: PropTypes.oneOf(["data", "labels", "parent"]),
       eventKey: PropTypes.oneOfType([
         PropTypes.func,
         CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -335,50 +335,87 @@ export default class VictoryPie extends React.Component {
   }
 
   componentWillMount() {
-    this.baseProps = PieHelpers.getBaseProps(this.props, defaultStyles);
+    this.setupEvents(this.props);
   }
 
   componentWillReceiveProps(newProps) {
-    this.baseProps = PieHelpers.getBaseProps(newProps, defaultStyles);
+    this.setupEvents(newProps);
   }
 
-  renderData(props) {
-    const { dataComponent, labelComponent, sharedEvents } = props;
-    const getSharedEventState = sharedEvents && isFunction(sharedEvents.getEventState) ?
+  setupEvents(props) {
+    const { sharedEvents } = props;
+    this.baseProps = PieHelpers.getBaseProps(props, defaultStyles);
+    this.dataKeys = Object.keys(this.baseProps).filter((key) => key !== "parent");
+    this.getSharedEventState = sharedEvents && isFunction(sharedEvents.getEventState) ?
       sharedEvents.getEventState : () => undefined;
-    return Object.keys(this.baseProps).map((key) => {
+  }
+
+  renderSlices(props) {
+    return this.dataKeys.map((key) => {
       const dataEvents = this.getEvents(props, "data", key);
       const dataProps = defaults(
         {key: `pie-${key}`},
         this.getEventState(key, "data"),
-        getSharedEventState(key, "data"),
+        this.getSharedEventState(key, "data"),
         this.baseProps[key].data,
-        dataComponent.props
+        props.dataComponent.props
       );
-      const pieComponent = React.cloneElement(dataComponent, Object.assign(
+      return React.cloneElement(props.dataComponent, Object.assign(
         {}, dataProps, {events: Events.getPartialEvents(dataEvents, key, dataProps)}
       ));
+    });
+  }
+
+  renderLabels(props) {
+    return this.dataKeys.reduce((memo, key) => {
       const labelProps = defaults(
         {key: `pie-label-${key}`},
         this.getEventState(key, "labels"),
-        getSharedEventState(key, "labels"),
+        this.getSharedEventState(key, "labels"),
         this.baseProps[key].labels,
-        labelComponent.props
+        props.labelComponent.props
       );
       if (labelProps && labelProps.text) {
         const labelEvents = this.getEvents(props, "labels", key);
-        const pieLabel = React.cloneElement(labelComponent, Object.assign({
+        const labelComponent = React.cloneElement(props.labelComponent, Object.assign({
           events: Events.getPartialEvents(labelEvents, key, labelProps)
         }, labelProps));
-        return (
-          <g key={`pie-group-${key}`}>
-            {pieComponent}
-            {pieLabel}
-          </g>
-        );
+        return memo.concat(labelComponent);
       }
-      return pieComponent;
-    });
+      return memo;
+    }, []);
+  }
+
+  renderData(props) {
+    const pie = this.renderSlices(props);
+    const pieLabels = this.renderLabels(props);
+    if (pieLabels.length > 0) {
+      return (
+        <g key={`pie-group`}>
+          {pie}
+          {pieLabels}
+        </g>
+      );
+    }
+    return pie;
+  }
+
+  renderContainer(props, group) {
+    const parentEvents = this.getEvents(props, "parent", "parent");
+    const parentProps = defaults(
+      {},
+      this.getEventState("parent", "parent"),
+      this.getSharedEventState("parent", "parent"),
+      props.containerComponent.props,
+      this.baseProps.parent
+    );
+    return React.cloneElement(
+      props.containerComponent,
+      Object.assign(
+        {}, parentProps, {events: Events.getPartialEvents(parentEvents, "parent", parentProps)}
+      ),
+      group
+    );
   }
 
   render() {
@@ -407,14 +444,6 @@ export default class VictoryPie extends React.Component {
       </g>
     );
 
-    return this.props.standalone ?
-      React.cloneElement(
-        this.props.containerComponent,
-        Object.assign({
-          height: this.props.height,
-          width: this.props.width,
-          style: style.parent}, this.props.containerComponent.props),
-        group) :
-      group;
+    return this.props.standalone ? this.renderContainer(this.props, group) : group;
   }
 }

--- a/test/client/spec/components/victory-pie.spec.js
+++ b/test/client/spec/components/victory-pie.spec.js
@@ -268,6 +268,24 @@ describe("components/victory-pie", () => {
   });
 
   describe("event handling", () => {
+    it("attaches an event to the parent svg", () => {
+      const clickHandler = sinon.spy();
+      const wrapper = mount(
+        <VictoryPie
+          events={[{
+            target: "parent",
+            eventHandlers: {onClick: clickHandler}
+          }]}
+        />
+      );
+      const svg = wrapper.find("svg");
+      svg.simulate("click");
+      expect(clickHandler).called;
+      // the first argument is the standard evt object
+      expect(clickHandler.args[0][1])
+        .to.include.keys("slices", "pathFunction", "width", "height", "style");
+    });
+
     it("attaches an event to data", () => {
       const clickHandler = sinon.spy();
       const wrapper = mount(


### PR DESCRIPTION
This PR
- supports events on the parent container component. parent event handlers are called with the event object as well as an object with `slices`,  `width`, `height`, and `styles`. 

- renders all data components before label components so that labels don't get overlapped by slices
closes https://github.com/FormidableLabs/victory-chart/issues/245