### PR TITLE
Change default styles to grayscale

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -50,7 +50,6 @@ class BorderLabelSlice extends React.Component {
 }
 
 export default class App extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -68,16 +67,10 @@ export default class App extends React.Component {
       sliceWidth: 60,
       style: {
         parent: {
+          backgroundColor: "#f7f7f7",
           border: "1px solid #ccc",
           margin: "2%",
           maxWidth: "40%"
-        },
-        data: {
-          strokeWidth: 2
-        },
-        labels: {
-          fill: "white",
-          padding: 10
         }
       }
     };
@@ -94,11 +87,11 @@ export default class App extends React.Component {
   }
 
   getTransitionData() {
-    const data = random(6, 10);
+    const data = random(6, 9);
     return range(data).map((datum) => {
       return {
         x: datum,
-        y: random(2, 10),
+        y: random(2, 9),
         label: `#${datum}`
       };
     });
@@ -129,6 +122,14 @@ export default class App extends React.Component {
       alignItems: "center",
       justifyContent: "center"
     };
+
+    const parentStyle = {
+      backgroundColor: "#f7f7f7",
+      border: "1px solid #ccc",
+      margin: "2%",
+      maxWidth: "40%"
+    };
+
     return (
       <div>
         <h1>VictoryPie Demo</h1>
@@ -136,8 +137,16 @@ export default class App extends React.Component {
         <div style={containerStyle}>
           <VictoryPie animate={{duration: 1000}}
             style={{
-              parent: {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"},
-              labels: {fontSize: 10, padding: 100, fill: "white"}
+              parent: parentStyle,
+              labels: {
+                fontSize: 10,
+                padding: 100,
+                paintOrder: "stroke",
+                stroke: "#ffffff",
+                strokeWidth: 3,
+                strokeLinecap: "butt",
+                strokeLinejoin: "miter"
+              }
             }}
             data={this.state.transitionData}
             containerComponent={
@@ -148,7 +157,10 @@ export default class App extends React.Component {
           />
 
           <VictoryPie
-            style={{parent: {maxWidth: "40%"}}}
+            style={{
+              parent: { ...parentStyle, padding: "1% 3%" },
+              labels: { padding: 230 }
+            }}
             theme={VictoryTheme.grayscale}
             labels={() => "click me!"}
             events={[{
@@ -196,17 +208,23 @@ export default class App extends React.Component {
 
           <VictoryPie
             style={{
-              parent: {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"},
+              parent: parentStyle,
               labels: {fontSize: 20, padding: 100, fill: "white"}
             }}
             colorScale="greyscale"
           />
 
-          <VictoryPie style={this.state.style} innerRadius={140} />
+          <VictoryPie
+            style={{
+              ...this.state.style,
+              labels: { padding: 60 }
+            }}
+            innerRadius={140}
+          />
 
           <VictoryPie
             style={{
-              parent: {border: "1px solid #ccc", margin: "2%", maxWidth: "40%"},
+              parent: parentStyle,
               data: {stroke: "transparent", opacity: 0.4}
             }}
           />
@@ -223,7 +241,7 @@ export default class App extends React.Component {
           />
 
           <VictoryPie
-            style={this.state.style}
+            style={{...this.state.style, labels: {padding: 110}}}
             data={this.state.data}
             innerRadius={100}
             animate={{duration: 2000}}
@@ -231,7 +249,7 @@ export default class App extends React.Component {
           />
 
           <VictoryPie
-            style={this.state.style}
+            style={{...this.state.style, labels: {padding: 60}}}
             endAngle={90}
             innerRadius={140}
             padAngle={5}
@@ -243,7 +261,7 @@ export default class App extends React.Component {
             x={0}
             y={1}
             animate={{duration: 2000}}
-            style={this.state.style}
+            style={{...this.state.style, data: {stroke: "#252525", strokeWidth: 2}}}
             colorScale="warm"
           />
 

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -13,28 +13,31 @@ import PieHelpers from "./helper-methods";
 const fallbackProps = {
   style: {
     data: {
-      padding: 5,
-      stroke: "white",
-      strokeWidth: 1
+      padding: 10,
+      stroke: "transparent",
+      strokeWidth: 0
     },
     labels: {
+      fill: "#252525",
+      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+      fontSize: 14,
+      letterSpacing: "0.04em",
       padding: 10,
-      fill: "black",
-      strokeWidth: 0,
       stroke: "transparent",
-      fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-      fontSize: 13,
+      strokeWidth: 0,
       textAnchor: "middle"
     }
   },
   colorScale: [
-    "#75C776",
-    "#39B6C5",
-    "#78CCC4",
-    "#62C3A4",
-    "#64A8D1",
-    "#8C95C8",
-    "#3BAF74"
+    "#ffffff",
+    "#f0f0f0",
+    "#d9d9d9",
+    "#bdbdbd",
+    "#969696",
+    "#737373",
+    "#525252",
+    "#252525",
+    "#000000"
   ]
 };
 


### PR DESCRIPTION
Now for pie! 

![screen shot 2016-07-06 at 4 36 03 pm](https://cloud.githubusercontent.com/assets/768965/16637919/bf1c74c4-4397-11e6-9b77-acbe24f19e37.png)

Default the base styles of the chart components to be the grayscale theme. It brings consistency across the components and makes a very solid base for creating more themes.

Also alphabetized the object keys.

/cc @ebrillhart @boygirl @kylecesmat