### PR TITLE
Add code exports to docs

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -17,6 +17,8 @@ class Docs extends React.Component {
           scope={{merge, random, range, React, ReactDOM, VictoryPie}}
           playgroundtheme="elegant"
           customRenderers={merge(appendLinkIcon, ecologyPlaygroundLoading)}
+          exportGist
+          copyToClipboard
         />
         <Style rules={VictoryTheme}/>
       </StyleRoot>


### PR DESCRIPTION
This will add the export buttons to the codeblocks when used in victory-docs