### PR TITLE
Simplify theme and fallback props

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "builder": "~2.9.1",
     "d3-shape": "^0.6.0",
     "lodash": "^4.12.0",
-    "victory-core": "^4.5.0"
+    "victory-core": "^5.0.0"
   },
   "devDependencies": {
     "@kadira/storybook": "^1.25.0",

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -24,8 +24,9 @@ export default {
     props = Helpers.modifyProps(props, fallbackProps, "pie");
     const calculatedValues = this.getCalculatedValues(props);
     const { slices, style, pathFunction, labelPosition } = calculatedValues;
-    const { width, height } = props;
-    const childProps = { parent: {slices, pathFunction, width, height, style: style.parent} };
+    const childProps = { parent: {
+      slices, pathFunction, width: props.width, height: props.height, style: style.parent}
+    };
     for (let index = 0, len = slices.length; index < len; index++) {
       const slice = slices[index];
       const datum = slice.data;

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -21,7 +21,8 @@ export default {
   },
 
   getBaseProps(props, fallbackProps) {
-    const calculatedValues = this.getCalculatedValues(props, fallbackProps);
+    props = Helpers.modifyProps(props, fallbackProps, "pie");
+    const calculatedValues = this.getCalculatedValues(props);
     const { slices, style, pathFunction, labelPosition } = calculatedValues;
     const { width, height } = props;
     const childProps = { parent: {slices, pathFunction, width, height, style: style.parent} };
@@ -64,17 +65,11 @@ export default {
     return childProps;
   },
 
-  getCalculatedValues(props, fallbackProps) {
-    const theme = props.theme && props.theme.pie;
-    const styleObject = theme ? props.theme.pie.style
-    : fallbackProps.style;
+  getCalculatedValues(props) {
+    const { theme, colorScale } = props;
+    const styleObject = theme && theme.pie && theme.pie.style ? theme.pie.style : {};
     const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
-    const getColorScale = () => {
-      return theme ? theme.props.colorScale : fallbackProps.colorScale;
-    };
-    const colorScale = props.colorScale || getColorScale();
-    const colors = Array.isArray(colorScale) ?
-    colorScale : Style.getColorScale(colorScale);
+    const colors = Array.isArray(colorScale) ? colorScale : Style.getColorScale(colorScale);
     const padding = Helpers.getPadding(props);
     const radius = this.getRadius(props, padding);
     const data = Events.addEventKeys(props, Helpers.getData(props));
@@ -104,9 +99,8 @@ export default {
 
   getLabelPosition(props, style, radius) {
     // TODO: better label positioning
-    const innerRadius = props.innerRadius ?
-    props.innerRadius + style.labels.padding :
-      style.labels.padding;
+    const padding = style && style.labels && style.labels.padding || 0;
+    const innerRadius = props.innerRadius ? props.innerRadius + padding : padding;
     return d3Shape.arc()
       .outerRadius(radius)
       .innerRadius(innerRadius);

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -3,31 +3,24 @@ import { assign, defaults, isFunction, partialRight } from "lodash";
 import {
   PropTypes as CustomPropTypes,
   Events,
+  Helpers,
   VictoryLabel,
   VictoryTransition,
-  VictoryContainer
+  VictoryContainer,
+  VictoryTheme
 } from "victory-core";
 import Slice from "./slice";
 import PieHelpers from "./helper-methods";
 
 const fallbackProps = {
-  style: {
-    data: {
-      padding: 10,
-      stroke: "transparent",
-      strokeWidth: 0
-    },
-    labels: {
-      fill: "#252525",
-      fontFamily: "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-      fontSize: 14,
-      letterSpacing: "0.04em",
-      padding: 10,
-      stroke: "transparent",
-      strokeWidth: 0,
-      textAnchor: "middle"
-    }
-  },
+  endAngle: 360,
+  height: 400,
+  innerRadius: 0,
+  cornerRadius: 0,
+  padAngle: 0,
+  padding: 30,
+  width: 400,
+  startAngle: 0,
   colorScale: [
     "#ffffff",
     "#f0f0f0",
@@ -325,21 +318,14 @@ export default class VictoryPie extends React.Component {
       { x: "D", y: 1 },
       { x: "E", y: 2 }
     ],
-    endAngle: 360,
-    height: 400,
-    innerRadius: 0,
-    cornerRadius: 0,
-    padAngle: 0,
-    padding: 30,
-    startAngle: 0,
     standalone: true,
-    width: 400,
     x: "x",
     y: "y",
     dataComponent: <Slice/>,
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
-    groupComponent: <g/>
+    groupComponent: <g/>,
+    theme: {}
   };
 
   static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers), fallbackProps);
@@ -436,26 +422,29 @@ export default class VictoryPie extends React.Component {
   }
 
   render() {
+    const props = Helpers.modifyProps(this.props, fallbackProps, "pie");
+
+    const { animate, standalone, theme } = props;
     // If animating, return a `VictoryAnimation` element that will create
     // a new `VictoryBar` with nearly identical props, except (1) tweened
     // and (2) `animate` set to null so we don't recurse forever.
-    if (this.props.animate) {
+    if (animate) {
       const whitelist = [
         "data", "endAngle", "height", "innerRadius", "cornerRadius", "padAngle", "padding",
         "colorScale", "startAngle", "style", "width"
       ];
       return (
-        <VictoryTransition animate={this.props.animate} animationWhitelist={whitelist}>
-          { React.createElement(this.constructor, this.props) }
+        <VictoryTransition animate={animate} animationWhitelist={whitelist}>
+          { React.createElement(this.constructor, props) }
         </VictoryTransition>
       );
     }
 
-    const calculatedProps = PieHelpers.getCalculatedValues(this.props, fallbackProps);
+    const calculatedProps = PieHelpers.getCalculatedValues(props, fallbackProps);
     const { style, padding, radius } = calculatedProps;
     const offset = { x: radius + padding.left, y: radius + padding.top };
-    const children = this.renderData(this.props, calculatedProps);
+    const children = this.renderData(props, calculatedProps);
     const group = this.renderGroup(children, style.parent, offset);
-    return this.props.standalone ? this.renderContainer(this.props, group) : group;
+    return this.props.standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -35,6 +35,8 @@ const fallbackProps = {
 };
 
 export default class VictoryPie extends React.Component {
+  static displayName = "VictoryPie";
+
   static defaultTransitions = {
     onExit: {
       duration: 500,
@@ -325,7 +327,7 @@ export default class VictoryPie extends React.Component {
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
-    theme: {}
+    theme: VictoryTheme.grayscale
   };
 
   static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers), fallbackProps);
@@ -424,7 +426,7 @@ export default class VictoryPie extends React.Component {
   render() {
     const props = Helpers.modifyProps(this.props, fallbackProps, "pie");
 
-    const { animate, standalone, theme } = props;
+    const { animate, standalone } = props;
     // If animating, return a `VictoryAnimation` element that will create
     // a new `VictoryBar` with nearly identical props, except (1) tweened
     // and (2) `animate` set to null so we don't recurse forever.
@@ -445,6 +447,6 @@ export default class VictoryPie extends React.Component {
     const offset = { x: radius + padding.left, y: radius + padding.top };
     const children = this.renderData(props, calculatedProps);
     const group = this.renderGroup(children, style.parent, offset);
-    return this.props.standalone ? this.renderContainer(props, group) : group;
+    return standalone ? this.renderContainer(props, group) : group;
   }
 }

--- a/test/client/spec/components/victory-pie.spec.js
+++ b/test/client/spec/components/victory-pie.spec.js
@@ -31,8 +31,7 @@ describe("components/victory-pie", () => {
         <VictoryPie/>
       );
       const svg = wrapper.find("svg");
-      const viewBoxValue = `0 0 ${VictoryPie.defaultProps.width} ${VictoryPie.defaultProps.height}`;
-      expect(svg.prop("viewBox")).to.equal(viewBoxValue);
+      expect(svg.prop("viewBox")).to.equal("0 0 400 400");
     });
 
     it("renders 5 slices", () => {
@@ -193,7 +192,7 @@ describe("components/victory-pie", () => {
         <VictoryPie width={width} />
       );
 
-      expect(wrapper.find("svg")).to.have.prop("viewBox", `0 0 ${width} ${VictoryPie.defaultProps.height}`);
+      expect(wrapper.find("svg")).to.have.prop("viewBox", `0 0 ${width} 400`);
     });
   });
 
@@ -204,7 +203,7 @@ describe("components/victory-pie", () => {
         <VictoryPie height={height} />
       );
 
-      expect(wrapper.find("svg")).to.have.prop("viewBox", `0 0 ${VictoryPie.defaultProps.width} ${height}`);
+      expect(wrapper.find("svg")).to.have.prop("viewBox", `0 0 400 ${height}`);
     });
   });
 


### PR DESCRIPTION
**depends on https://github.com/FormidableLabs/victory-core/pull/110**

This PR:
- removes all styles from `fallbackProps` across all components
- adds `theme: VictoryTheme.grayscale` to defaultProps
- adds checks for missing / expected style objects
