### PR TITLE
update for tooltip, implement labelRadius

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2,9 +2,8 @@
 import { merge, random, range } from "lodash";
 import React from "react";
 import { VictoryPie } from "../src/index";
-import Slice from "../src/components/slice";
 import {
-  VictoryContainer, VictoryTheme
+  VictoryContainer, VictoryTheme, Slice, VictoryTooltip
 } from "victory-core";
 
 class BorderLabelSlice extends React.Component {
@@ -140,7 +139,6 @@ export default class App extends React.Component {
               parent: parentStyle,
               labels: {
                 fontSize: 10,
-                padding: 100,
                 paintOrder: "stroke",
                 stroke: "#ffffff",
                 strokeWidth: 3,
@@ -158,8 +156,7 @@ export default class App extends React.Component {
 
           <VictoryPie
             style={{
-              parent: { ...parentStyle, padding: "1% 3%" },
-              labels: { padding: 230 }
+              parent: { ...parentStyle, padding: "1% 3%" }
             }}
             theme={VictoryTheme.material}
             labels={() => "click me!"}
@@ -210,13 +207,15 @@ export default class App extends React.Component {
           <VictoryPie
             style={{
               parent: parentStyle,
-              labels: {fontSize: 20, padding: 100, fill: "white"}
+              labels: {fontSize: 10, padding: 10}
             }}
+            labelComponent={<VictoryTooltip/>}
             colorScale="greyscale"
           />
 
           <VictoryPie
             style={{...this.state.style}}
+            labelRadius={120}
             innerRadius={140}
           />
 
@@ -242,6 +241,7 @@ export default class App extends React.Component {
             style={{...this.state.style, labels: {padding: 0}}}
             data={this.state.data}
             innerRadius={100}
+            labelRadius={110}
             animate={{duration: 2000}}
             colorScale={this.state.colorScale}
           />

--- a/docs/victory-pie/ecology.md
+++ b/docs/victory-pie/ecology.md
@@ -43,14 +43,15 @@ assign a property to x or y, or process data on the fly.
 
 ### Flexible and Configurable
 
-Labels are placed at the centroid of each pie slice by default. Apply styles to the labels, or apply padding to move the labels:
+Labels are placed at the outer edge of the pie by default. Set a `labelRadius` to adjust the position of the labels
 
 ``` playground
 <VictoryPie
+  labelRadius={80}
   style={{
     labels: {
       fontSize: 20,
-      padding: 100
+      fill: "white"
     }
   }}
 />
@@ -62,7 +63,7 @@ Styles of the pie chart itself can also be specified:
 <VictoryPie
   style={{
     data: {
-      stroke: "black",
+      stroke: "tomato",
       strokeDasharray: "5,5",
       strokeWidth: 2
     }
@@ -70,7 +71,7 @@ Styles of the pie chart itself can also be specified:
 />
 ```
 
-Set the `innerRadius` prop to create a donut chart. Label positions will automatically adjust.
+Set the `innerRadius` prop to create a donut chart.
 
 ``` playground
 <VictoryPie innerRadius={140}/>
@@ -104,8 +105,7 @@ Here's an example of a donut chart with custom data and colors
     labels: {
       fill: "white",
       fontSize: 12,
-      fontWeight: "bold",
-      padding: 0
+      fontWeight: "bold"
     }
   }}
   data={[
@@ -117,7 +117,8 @@ Here's an example of a donut chart with custom data and colors
     {x: "45-64", y: 4263},
     {x: "≥65", y: 7502}
   ]}
-  innerRadius={110}
+  innerRadius={100}
+  labelRadius={110}
   colorScale={[
     "#D85F49",
     "#F66D3B",
@@ -162,6 +163,7 @@ The `eventKey` may optionally be used to select a single element by index rather
 
 ``` playground
   <VictoryPie
+    padding={75}
     data={[
       {x: "Cat", y: 62},
       {x: "Dog", y: 91},

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "builder": "~2.9.1",
     "d3-shape": "^0.6.0",
     "lodash": "^4.12.0",
-    "victory-core": "^6.0.0"
+    "victory-core": "^6.1.1"
   },
   "devDependencies": {
     "@kadira/storybook": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "builder": "~2.9.1",
     "d3-shape": "^0.6.0",
     "lodash": "^4.12.0",
-    "victory-core": "^6.1.1"
+    "victory-core": "^7.0.0"
   },
   "devDependencies": {
     "@kadira/storybook": "^1.25.0",


### PR DESCRIPTION
This PR 

- adds support for `VictoryTooltip`
- implements perf improvements
- adds a `labelRadius` prop that is easier to understand that trying to position labels with padding
- Sets text anchor and vertical anchor based on the angle of the pie slice
- Fixes demos and docs for modified styles