### PR TITLE
dont render tooltips in portals for pie

### DIFF
--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import { partialRight } from "lodash";
+import { partialRight, assign } from "lodash";
 import {
   addEvents,
   Helpers,
@@ -137,6 +137,10 @@ class VictoryPie extends React.Component {
 
   static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers), fallbackProps);
 
+  static expectedComponents = [
+    "dataComponent", "labelComponent", "groupComponent", "containerComponent"
+  ];
+
   renderData(props) {
     const { dataComponent, labelComponent, groupComponent } = props;
     const dataComponents = [];
@@ -147,7 +151,9 @@ class VictoryPie extends React.Component {
 
       const labelProps = this.getComponentProps(labelComponent, "labels", index);
       if (labelProps && labelProps.text !== undefined && labelProps.text !== null) {
-        labelComponents[index] = React.cloneElement(labelComponent, labelProps);
+        labelComponents[index] = React.cloneElement(
+          labelComponent, assign({}, labelProps, {renderInPortal: false})
+          );
       }
     }
     return labelComponents.length > 0 ?

--- a/test/client/spec/components/victory-pie.spec.js
+++ b/test/client/spec/components/victory-pie.spec.js
@@ -321,8 +321,7 @@ describe("components/victory-pie", () => {
         node.simulate("click");
         expect(clickHandler.called).to.equal(true);
         // the first argument is the standard evt object
-        expect(omit(clickHandler.args[index][1], ["events", "key"]))
-          .to.eql(omit(initialProps, ["events", "key"]));
+        expect(clickHandler.args[index][1].datum).to.eql(initialProps.datum);
         expect(`${clickHandler.args[index][2]}`).to.eql(`${index}`);
       });
     });


### PR DESCRIPTION
Automatically rendering tooltips in VictoryPortal was moving tooltips off screen rather than in the translated group that the pie is rendered into.