### PR TITLE
Update to React 15.5.

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,5 +1,6 @@
 /*global window:false*/
 import { merge, random, range } from "lodash";
+import PropTypes from "prop-types";
 import React from "react";
 import { VictoryPie } from "../src/index";
 import {
@@ -9,7 +10,7 @@ import {
 class BorderLabelSlice extends React.Component {
   static propTypes = {
     ...Slice.propTypes,
-    index: React.PropTypes.number
+    index: PropTypes.number
   };
 
   render() {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "builder-victory-component": "^3.1.0",
     "d3-shape": "^1.0.0",
     "lodash": "^4.12.0",
+    "prop-types": "~15.5.8",
     "victory-core": "^14.0.7"
   },
   "devDependencies": {
@@ -40,10 +41,11 @@
     "chai-enzyme": "0.4.1",
     "enzyme": "^2.3.0",
     "mocha": "^2.2.5",
-    "react": "~15.1.0",
-    "react-addons-test-utils": "~15.1.0",
-    "react-dom": "~15.1.0",
+    "react": "~15.5.4",
+    "react-addons-test-utils": "~15.5.1",
+    "react-dom": "~15.5.4",
     "react-router": "^2.4.0",
+    "react-test-renderer": "~15.5.4",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0"
   },

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { partialRight, assign } from "lodash";
 import {
   addEvents,


### PR DESCRIPTION
Since React 16 is right around the corner, Facebook released v.15.5 to make the migration easier. This also moved the `PropTypes` into their own npm module `prop-types`.  
More info: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

This pull request replaces all the `PropTypes` imports from `react` to the new `prop-types` package and updates `react` and `react-dom` to their current versions.