### PR TITLE
Fixed role not defined in victory-pie.js

### DIFF
--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -38,6 +38,8 @@ const animationWhitelist = [
 class VictoryPie extends React.Component {
   static displayName = "VictoryPie";
 
+  static role = "pie";
+
   static defaultTransitions = {
     onExit: {
       duration: 500,


### PR DESCRIPTION
Role was not defined in victory-pie.js, which caused the function modifyProps to not work properly. 
It fixes the theme not being applied if the animate props was set (#841).  