### PR TITLE
[ENH] Add sortOrder prop

### DIFF
--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -104,6 +104,7 @@ class VictoryPie extends React.Component {
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string)
     ]),
+    sortOder: PropTypes.oneOf(["ascending", "descending"]),
     standalone: PropTypes.bool,
     startAngle: PropTypes.number,
     style: PropTypes.shape({
@@ -138,6 +139,7 @@ class VictoryPie extends React.Component {
     labelComponent: <VictoryLabel/>,
     containerComponent: <VictoryContainer/>,
     groupComponent: <g/>,
+    sortOrder: "ascending",
     theme: VictoryTheme.grayscale
   };
 

--- a/test/client/spec/components/victory-pie.spec.js
+++ b/test/client/spec/components/victory-pie.spec.js
@@ -157,7 +157,7 @@ describe("components/victory-pie", () => {
       const data = range(9).map((i) => ({ x: i, y: i }));
 
       const wrapper = shallow(
-        <VictoryPie data={data} sortKey={"x"} sortOder={"descending"}/>
+        <VictoryPie data={data} sortKey={"x"} sortOrder={"descending"}/>
       );
       const xValues = wrapper.find(Slice).map((slice) => {
         return slice.prop("datum")._x;

--- a/test/client/spec/components/victory-pie.spec.js
+++ b/test/client/spec/components/victory-pie.spec.js
@@ -152,6 +152,20 @@ describe("components/victory-pie", () => {
 
       expect(xValues).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8]);
     });
+
+    it("renders data values sorted by sortKey prop and sortOrder", () => {
+      const data = range(9).map((i) => ({ x: i, y: i }));
+
+      const wrapper = shallow(
+        <VictoryPie data={data} sortKey={"x"} sortOder={"descending"}/>
+      );
+      const xValues = wrapper.find(Slice).map((slice) => {
+        return slice.prop("datum")._x;
+      });
+
+      expect(xValues).to.eql([8, 7, 6, 5, 4, 3, 2, 1, 0]);
+    });
+
   });
 
   describe("the `startAngle` prop", () => {


### PR DESCRIPTION
Fixes: FormidableLabs/victory#870

This fix uses the new `sortOrder` key. We can specify the `ascending` or `descending` order for `sortKey`

Tests will fail until we upgrade victory-core dependency with fix from https://github.com/FormidableLabs/victory-core/pull/322


Thanks!