### PR TITLE
Export helper methods as named exports

### DIFF
--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -18,14 +18,14 @@ export const checkForValidText = (text) => {
 
 export const getSliceStyle = (datum, index, calculatedValues) => {
   const { style, colors } = calculatedValues;
-  const fill = this.getColor(style, colors, index);
+  const fill = getColor(style, colors, index);
   const dataStyles = omit(datum, ["_x", "_y", "x", "y", "label"]);
   return defaults({}, dataStyles, { fill }, style.data);
 };
 
 export const getBaseProps = (props, fallbackProps) => {
   props = Helpers.modifyProps(props, fallbackProps, "pie");
-  const calculatedValues = this.getCalculatedValues(props);
+  const calculatedValues = getCalculatedValues(props);
   const { slices, style, pathFunction, data, origin } = calculatedValues;
   const childProps = {
     parent: {
@@ -40,12 +40,12 @@ export const getBaseProps = (props, fallbackProps) => {
     const eventKey = datum.eventKey || index;
     const dataProps = {
       index, slice, pathFunction, datum, data, origin,
-      style: this.getSliceStyle(datum, index, calculatedValues)
+      style: getSliceStyle(datum, index, calculatedValues)
     };
 
     childProps[eventKey] = {
       data: dataProps,
-      labels: this.getLabelProps(props, dataProps, calculatedValues)
+      labels: getLabelProps(props, dataProps, calculatedValues)
     };
   }
   return childProps;
@@ -58,17 +58,17 @@ export const getLabelProps = (props, dataProps, calculatedValues) => {
     assign({ padding: 0 }, style.labels), datum, props.active
   );
   const labelRadius = Helpers.evaluateProp(props.labelRadius, datum);
-  const labelPosition = this.getLabelPosition(radius, labelRadius, labelStyle);
+  const labelPosition = getLabelPosition(radius, labelRadius, labelStyle);
   const position = labelPosition.centroid(slice);
-  const orientation = this.getLabelOrientation(slice);
+  const orientation = getLabelOrientation(slice);
   return {
     index, datum, data, slice, orientation,
     style: labelStyle,
     x: Math.round(position[0]) + origin.x,
     y: Math.round(position[1]) + origin.y,
-    text: this.getLabelText(props, datum, index),
-    textAnchor: labelStyle.textAnchor || this.getTextAnchor(orientation),
-    verticalAnchor: labelStyle.verticalAnchor || this.getVerticalAnchor(orientation),
+    text: getLabelText(props, datum, index),
+    textAnchor: labelStyle.textAnchor || getTextAnchor(orientation),
+    verticalAnchor: labelStyle.verticalAnchor || getVerticalAnchor(orientation),
     angle: labelStyle.angle
   };
 };
@@ -79,12 +79,12 @@ export const getCalculatedValues = (props) => {
   const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
   const colors = Array.isArray(colorScale) ? colorScale : Style.getColorScale(colorScale);
   const padding = Helpers.getPadding(props);
-  const radius = this.getRadius(props, padding);
+  const radius = getRadius(props, padding);
   const offsetWidth = ((radius + padding.left) + (width - radius - padding.right)) / 2;
   const offsetHeight = ((radius + padding.top) + (height - radius - padding.bottom)) / 2;
   const origin = { x: offsetWidth, y: offsetHeight };
   const data = Data.getData(props);
-  const slices = this.getSlices(props, data);
+  const slices = getSlices(props, data);
   const pathFunction = d3Shape.arc()
     .cornerRadius(props.cornerRadius)
     .outerRadius(radius)
@@ -155,15 +155,15 @@ export const getLabelText = (props, datum, index) => {
   } else {
     text = isFunction(props.labels) ? props.labels(datum) : datum.xName || datum._x;
   }
-  return this.checkForValidText(text);
+  return checkForValidText(text);
 };
 
 export const getSlices = (props, data) => {
   const layoutFunction = d3Shape.pie()
     .sort(null)
-    .startAngle(this.degreesToRadians(props.startAngle))
-    .endAngle(this.degreesToRadians(props.endAngle))
-    .padAngle(this.degreesToRadians(props.padAngle))
+    .startAngle(degreesToRadians(props.startAngle))
+    .endAngle(degreesToRadians(props.endAngle))
+    .padAngle(degreesToRadians(props.padAngle))
     .value((datum) => { return datum._y; });
   return layoutFunction(data);
 };

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -4,11 +4,11 @@ import * as d3Shape from "d3-shape";
 
 import { Helpers, Data, Style } from "victory-core";
 
-export const degreesToRadians = (degrees) => {
+const degreesToRadians = (degrees) => {
   return degrees * (Math.PI / 180);
 };
 
-export const checkForValidText = (text) => {
+const checkForValidText = (text) => {
   if (text === undefined || text === null) {
     return text;
   } else {
@@ -16,21 +16,21 @@ export const checkForValidText = (text) => {
   }
 };
 
-export const getColor = (style, colors, index) => {
+const getColor = (style, colors, index) => {
   if (style && style.data && style.data.fill) {
     return style.data.fill;
   }
   return colors && colors[index % colors.length];
 };
 
-export const getRadius = (props, padding) => {
+const getRadius = (props, padding) => {
   return Math.min(
     props.width - padding.left - padding.right,
     props.height - padding.top - padding.bottom
   ) / 2;
 };
 
-export const getSlices = (props, data) => {
+const getSlices = (props, data) => {
   const layoutFunction = d3Shape.pie()
     .sort(null)
     .startAngle(degreesToRadians(props.startAngle))
@@ -40,7 +40,7 @@ export const getSlices = (props, data) => {
   return layoutFunction(data);
 };
 
-export const getCalculatedValues = (props) => {
+const getCalculatedValues = (props) => {
   const { theme, colorScale, width, height } = props;
   const styleObject = theme && theme.pie && theme.pie.style ? theme.pie.style : {};
   const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
@@ -59,14 +59,14 @@ export const getCalculatedValues = (props) => {
   return { style, colors, padding, radius, data, slices, pathFunction, origin };
 };
 
-export const getSliceStyle = (datum, index, calculatedValues) => {
+const getSliceStyle = (datum, index, calculatedValues) => {
   const { style, colors } = calculatedValues;
   const fill = getColor(style, colors, index);
   const dataStyles = omit(datum, ["_x", "_y", "x", "y", "label"]);
   return defaults({}, dataStyles, { fill }, style.data);
 };
 
-export const getLabelText = (props, datum, index) => {
+const getLabelText = (props, datum, index) => {
   let text;
   if (datum.label) {
     text = datum.label;
@@ -78,7 +78,7 @@ export const getLabelText = (props, datum, index) => {
   return checkForValidText(text);
 };
 
-export const getLabelPosition = (radius, labelRadius, style) => {
+const getLabelPosition = (radius, labelRadius, style) => {
   const padding = style && style.padding || 0;
   const arcRadius = labelRadius || radius + padding;
   return d3Shape.arc()
@@ -86,7 +86,7 @@ export const getLabelPosition = (radius, labelRadius, style) => {
     .innerRadius(arcRadius);
 };
 
-export const getLabelOrientation = (slice) => {
+const getLabelOrientation = (slice) => {
   const radiansToDegrees = (radians) => {
     return radians * (180 / Math.PI);
   };
@@ -104,21 +104,21 @@ export const getLabelOrientation = (slice) => {
   }
 };
 
-export const getTextAnchor = (orientation) => {
+const getTextAnchor = (orientation) => {
   if (orientation === "top" || orientation === "bottom") {
     return "middle";
   }
   return orientation === "right" ? "start" : "end";
 };
 
-export const getVerticalAnchor = (orientation) => {
+const getVerticalAnchor = (orientation) => {
   if (orientation === "left" || orientation === "right") {
     return "middle";
   }
   return orientation === "bottom" ? "start" : "end";
 };
 
-export const getLabelProps = (props, dataProps, calculatedValues) => {
+const getLabelProps = (props, dataProps, calculatedValues) => {
   const { index, datum, data, slice } = dataProps;
   const { style, radius, origin } = calculatedValues;
   const labelStyle = Helpers.evaluateStyle(

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -4,168 +4,166 @@ import * as d3Shape from "d3-shape";
 
 import { Helpers, Data, Style } from "victory-core";
 
-export default {
-  degreesToRadians(degrees) {
-    return degrees * (Math.PI / 180);
-  },
+export const degreesToRadians = (degrees) => {
+  return degrees * (Math.PI / 180);
+};
 
-  checkForValidText(text) {
-    if (text === undefined || text === null) {
-      return text;
-    } else {
-      return `${text}`;
-    }
-  },
-
-  getSliceStyle(datum, index, calculatedValues) {
-    const { style, colors } = calculatedValues;
-    const fill = this.getColor(style, colors, index);
-    const dataStyles = omit(datum, ["_x", "_y", "x", "y", "label"]);
-    return defaults({}, dataStyles, { fill }, style.data);
-  },
-
-  getBaseProps(props, fallbackProps) {
-    props = Helpers.modifyProps(props, fallbackProps, "pie");
-    const calculatedValues = this.getCalculatedValues(props);
-    const { slices, style, pathFunction, data, origin } = calculatedValues;
-    const childProps = {
-      parent: {
-        standalone: props.standalone, slices, pathFunction,
-        width: props.width, height: props.height, style: style.parent
-      }
-    };
-
-    for (let index = 0, len = slices.length; index < len; index++) {
-      const slice = slices[index];
-      const datum = data[index];
-      const eventKey = datum.eventKey || index;
-      const dataProps = {
-        index, slice, pathFunction, datum, data, origin,
-        style: this.getSliceStyle(datum, index, calculatedValues)
-      };
-
-      childProps[eventKey] = {
-        data: dataProps,
-        labels: this.getLabelProps(props, dataProps, calculatedValues)
-      };
-    }
-    return childProps;
-  },
-
-  getLabelProps(props, dataProps, calculatedValues) {
-    const { index, datum, data, slice } = dataProps;
-    const { style, radius, origin } = calculatedValues;
-    const labelStyle = Helpers.evaluateStyle(
-      assign({ padding: 0 }, style.labels), datum, props.active
-    );
-    const labelRadius = Helpers.evaluateProp(props.labelRadius, datum);
-    const labelPosition = this.getLabelPosition(radius, labelRadius, labelStyle);
-    const position = labelPosition.centroid(slice);
-    const orientation = this.getLabelOrientation(slice);
-    return {
-      index, datum, data, slice, orientation,
-      style: labelStyle,
-      x: Math.round(position[0]) + origin.x,
-      y: Math.round(position[1]) + origin.y,
-      text: this.getLabelText(props, datum, index),
-      textAnchor: labelStyle.textAnchor || this.getTextAnchor(orientation),
-      verticalAnchor: labelStyle.verticalAnchor || this.getVerticalAnchor(orientation),
-      angle: labelStyle.angle
-    };
-  },
-
-  getCalculatedValues(props) {
-    const { theme, colorScale, width, height } = props;
-    const styleObject = theme && theme.pie && theme.pie.style ? theme.pie.style : {};
-    const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
-    const colors = Array.isArray(colorScale) ? colorScale : Style.getColorScale(colorScale);
-    const padding = Helpers.getPadding(props);
-    const radius = this.getRadius(props, padding);
-    const offsetWidth = ((radius + padding.left) + (width - radius - padding.right)) / 2;
-    const offsetHeight = ((radius + padding.top) + (height - radius - padding.bottom)) / 2;
-    const origin = { x: offsetWidth, y: offsetHeight };
-    const data = Data.getData(props);
-    const slices = this.getSlices(props, data);
-    const pathFunction = d3Shape.arc()
-      .cornerRadius(props.cornerRadius)
-      .outerRadius(radius)
-      .innerRadius(props.innerRadius);
-    return { style, colors, padding, radius, data, slices, pathFunction, origin };
-  },
-
-  getColor(style, colors, index) {
-    if (style && style.data && style.data.fill) {
-      return style.data.fill;
-    }
-    return colors && colors[index % colors.length];
-  },
-
-  getRadius(props, padding) {
-    return Math.min(
-      props.width - padding.left - padding.right,
-      props.height - padding.top - padding.bottom
-    ) / 2;
-  },
-
-  getLabelPosition(radius, labelRadius, style) {
-    const padding = style && style.padding || 0;
-    const arcRadius = labelRadius || radius + padding;
-    return d3Shape.arc()
-      .outerRadius(arcRadius)
-      .innerRadius(arcRadius);
-  },
-
-  getLabelOrientation(slice) {
-    const radiansToDegrees = (radians) => {
-      return radians * (180 / Math.PI);
-    };
-    const start = radiansToDegrees(slice.startAngle);
-    const end = radiansToDegrees(slice.endAngle);
-    const degree = start + (end - start) / 2;
-    if (degree < 45 || degree > 315) {
-      return "top";
-    } else if (degree >= 45 && degree < 135) {
-      return "right";
-    } else if (degree >= 135 && degree < 225) {
-      return "bottom";
-    } else {
-      return "left";
-    }
-  },
-
-  getTextAnchor(orientation) {
-    if (orientation === "top" || orientation === "bottom") {
-      return "middle";
-    }
-    return orientation === "right" ? "start" : "end";
-  },
-
-  getVerticalAnchor(orientation) {
-    if (orientation === "left" || orientation === "right") {
-      return "middle";
-    }
-    return orientation === "bottom" ? "start" : "end";
-  },
-
-  getLabelText(props, datum, index) {
-    let text;
-    if (datum.label) {
-      text = datum.label;
-    } else if (Array.isArray(props.labels)) {
-      text = props.labels[index];
-    } else {
-      text = isFunction(props.labels) ? props.labels(datum) : datum.xName || datum._x;
-    }
-    return this.checkForValidText(text);
-  },
-
-  getSlices(props, data) {
-    const layoutFunction = d3Shape.pie()
-      .sort(null)
-      .startAngle(this.degreesToRadians(props.startAngle))
-      .endAngle(this.degreesToRadians(props.endAngle))
-      .padAngle(this.degreesToRadians(props.padAngle))
-      .value((datum) => { return datum._y; });
-    return layoutFunction(data);
+export const checkForValidText = (text) => {
+  if (text === undefined || text === null) {
+    return text;
+  } else {
+    return `${text}`;
   }
+};
+
+export const getSliceStyle = (datum, index, calculatedValues) => {
+  const { style, colors } = calculatedValues;
+  const fill = this.getColor(style, colors, index);
+  const dataStyles = omit(datum, ["_x", "_y", "x", "y", "label"]);
+  return defaults({}, dataStyles, { fill }, style.data);
+};
+
+export const getBaseProps = (props, fallbackProps) => {
+  props = Helpers.modifyProps(props, fallbackProps, "pie");
+  const calculatedValues = this.getCalculatedValues(props);
+  const { slices, style, pathFunction, data, origin } = calculatedValues;
+  const childProps = {
+    parent: {
+      standalone: props.standalone, slices, pathFunction,
+      width: props.width, height: props.height, style: style.parent
+    }
+  };
+
+  for (let index = 0, len = slices.length; index < len; index++) {
+    const slice = slices[index];
+    const datum = data[index];
+    const eventKey = datum.eventKey || index;
+    const dataProps = {
+      index, slice, pathFunction, datum, data, origin,
+      style: this.getSliceStyle(datum, index, calculatedValues)
+    };
+
+    childProps[eventKey] = {
+      data: dataProps,
+      labels: this.getLabelProps(props, dataProps, calculatedValues)
+    };
+  }
+  return childProps;
+};
+
+export const getLabelProps = (props, dataProps, calculatedValues) => {
+  const { index, datum, data, slice } = dataProps;
+  const { style, radius, origin } = calculatedValues;
+  const labelStyle = Helpers.evaluateStyle(
+    assign({ padding: 0 }, style.labels), datum, props.active
+  );
+  const labelRadius = Helpers.evaluateProp(props.labelRadius, datum);
+  const labelPosition = this.getLabelPosition(radius, labelRadius, labelStyle);
+  const position = labelPosition.centroid(slice);
+  const orientation = this.getLabelOrientation(slice);
+  return {
+    index, datum, data, slice, orientation,
+    style: labelStyle,
+    x: Math.round(position[0]) + origin.x,
+    y: Math.round(position[1]) + origin.y,
+    text: this.getLabelText(props, datum, index),
+    textAnchor: labelStyle.textAnchor || this.getTextAnchor(orientation),
+    verticalAnchor: labelStyle.verticalAnchor || this.getVerticalAnchor(orientation),
+    angle: labelStyle.angle
+  };
+};
+
+export const getCalculatedValues = (props) => {
+  const { theme, colorScale, width, height } = props;
+  const styleObject = theme && theme.pie && theme.pie.style ? theme.pie.style : {};
+  const style = Helpers.getStyles(props.style, styleObject, "auto", "100%");
+  const colors = Array.isArray(colorScale) ? colorScale : Style.getColorScale(colorScale);
+  const padding = Helpers.getPadding(props);
+  const radius = this.getRadius(props, padding);
+  const offsetWidth = ((radius + padding.left) + (width - radius - padding.right)) / 2;
+  const offsetHeight = ((radius + padding.top) + (height - radius - padding.bottom)) / 2;
+  const origin = { x: offsetWidth, y: offsetHeight };
+  const data = Data.getData(props);
+  const slices = this.getSlices(props, data);
+  const pathFunction = d3Shape.arc()
+    .cornerRadius(props.cornerRadius)
+    .outerRadius(radius)
+    .innerRadius(props.innerRadius);
+  return { style, colors, padding, radius, data, slices, pathFunction, origin };
+};
+
+export const getColor = (style, colors, index) => {
+  if (style && style.data && style.data.fill) {
+    return style.data.fill;
+  }
+  return colors && colors[index % colors.length];
+};
+
+export const getRadius = (props, padding) => {
+  return Math.min(
+    props.width - padding.left - padding.right,
+    props.height - padding.top - padding.bottom
+  ) / 2;
+};
+
+export const getLabelPosition = (radius, labelRadius, style) => {
+  const padding = style && style.padding || 0;
+  const arcRadius = labelRadius || radius + padding;
+  return d3Shape.arc()
+    .outerRadius(arcRadius)
+    .innerRadius(arcRadius);
+};
+
+export const getLabelOrientation = (slice) => {
+  const radiansToDegrees = (radians) => {
+    return radians * (180 / Math.PI);
+  };
+  const start = radiansToDegrees(slice.startAngle);
+  const end = radiansToDegrees(slice.endAngle);
+  const degree = start + (end - start) / 2;
+  if (degree < 45 || degree > 315) {
+    return "top";
+  } else if (degree >= 45 && degree < 135) {
+    return "right";
+  } else if (degree >= 135 && degree < 225) {
+    return "bottom";
+  } else {
+    return "left";
+  }
+};
+
+export const getTextAnchor = (orientation) => {
+  if (orientation === "top" || orientation === "bottom") {
+    return "middle";
+  }
+  return orientation === "right" ? "start" : "end";
+};
+
+export const getVerticalAnchor = (orientation) => {
+  if (orientation === "left" || orientation === "right") {
+    return "middle";
+  }
+  return orientation === "bottom" ? "start" : "end";
+};
+
+export const getLabelText = (props, datum, index) => {
+  let text;
+  if (datum.label) {
+    text = datum.label;
+  } else if (Array.isArray(props.labels)) {
+    text = props.labels[index];
+  } else {
+    text = isFunction(props.labels) ? props.labels(datum) : datum.xName || datum._x;
+  }
+  return this.checkForValidText(text);
+};
+
+export const getSlices = (props, data) => {
+  const layoutFunction = d3Shape.pie()
+    .sort(null)
+    .startAngle(this.degreesToRadians(props.startAngle))
+    .endAngle(this.degreesToRadians(props.endAngle))
+    .padAngle(this.degreesToRadians(props.padAngle))
+    .value((datum) => { return datum._y; });
+  return layoutFunction(data);
 };

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -6,7 +6,7 @@ import {
   addEvents, Helpers, Data, PropTypes as CustomPropTypes, Slice,
   VictoryContainer, VictoryLabel, VictoryTheme
 } from "victory-core";
-import PieHelpers from "./helper-methods";
+import * as PieHelpers from "./helper-methods";
 
 const fallbackProps = {
   endAngle: 360,

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -6,7 +6,7 @@ import {
   addEvents, Helpers, Data, PropTypes as CustomPropTypes, Slice,
   VictoryContainer, VictoryLabel, VictoryTheme
 } from "victory-core";
-import * as PieHelpers from "./helper-methods";
+import { getBaseProps } from "./helper-methods";
 
 const fallbackProps = {
   endAngle: 360,
@@ -160,7 +160,7 @@ class VictoryPie extends React.Component {
     theme: VictoryTheme.grayscale
   };
 
-  static getBaseProps = partialRight(PieHelpers.getBaseProps.bind(PieHelpers), fallbackProps);
+  static getBaseProps = partialRight(getBaseProps, fallbackProps);
   static getData = Data.getData.bind(Data);
   static expectedComponents = [
     "dataComponent", "labelComponent", "groupComponent", "containerComponent"


### PR DESCRIPTION
Issue: [#650](https://github.com/FormidableLabs/victory/issues/650)

- Export all methods individually as named exports, instead of export all helpers as a default export in the form of an object
- Reorder the method definitions to counter eslint's `no-use-before-define` errors. This makes the diff look mighty weird, so it might be easier to look at the individual commits' diff

I'll be happy to make any changes you find necessary.