### PR TITLE
update victory core and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # VictoryPie Changelog
 
+## 15.0.0 (2018-04-21)
+
+**Breaking Changes**
+
+-[176](https://github.com/FormidableLabs/victory-pie/pull/176) Disable styles on data
+
+This change deprecates Victory's ability to automatically pick up style attributes from the data object. This change will improve performance, but will be a breaking change for many users. Fortunately the upgrade path is simple:
+
+If your data object looks like
+```
+data={[
+  { x: 1, y: 1, fill: "red", opacity: 0.2 },
+  ...
+]}
+```
+Add the following functional styles:
+```
+style={{ data:  { fill: (d) => d.fill, opacity: (d) => d.opacity } }}
+```
+and everything will work as before.
+
+Other changes:
+-[177](https://github.com/FormidableLabs/victory-pie/pull/177) Audit lodash methods
+
 ## 14.0.2 (2018-03-27)
 
 -[168](https://github.com/FormidableLabs/victory-pie/pull/168) Refactor helper method exports

--- a/package-lock.json
+++ b/package-lock.json
@@ -3708,9 +3708,9 @@
       "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
     },
     "d3-color": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-      "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.1.0.tgz",
+      "integrity": "sha512-IZVcqX5yYFvR2NUBbSfIfbgNcSgAtZ7JbgQWqDXf4CywtN7agvI7Kw6+Q1ETvlHOHWJT55Kyuzt0C3I0GVtRHQ=="
     },
     "d3-ease": {
       "version": "1.0.3",
@@ -3727,7 +3727,7 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
       "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
       "requires": {
-        "d3-color": "1.0.3"
+        "d3-color": "1.1.0"
       }
     },
     "d3-path": {
@@ -3742,7 +3742,7 @@
       "requires": {
         "d3-array": "1.2.1",
         "d3-collection": "1.0.4",
-        "d3-color": "1.0.3",
+        "d3-color": "1.1.0",
         "d3-format": "1.2.2",
         "d3-interpolate": "1.1.6",
         "d3-time": "1.0.8",
@@ -11612,6 +11612,11 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-fast-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-1.0.0.tgz",
+      "integrity": "sha512-dcQpdWr62flXQJuM8/bVEY5/10ad2SYBUafp8H4q4WHR3fTA/MMlp8mpzX12I0CCoEJc1P6QdiMg7U+7lFS6Rw=="
+    },
     "react-fuzzy": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.2.tgz",
@@ -13890,16 +13895,17 @@
       }
     },
     "victory-core": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-21.1.1.tgz",
-      "integrity": "sha512-mS6CYxmw26KaiVo1FTAKfDTRzsSRJS7DhWcZ0O97/CRgzpVSilZzP/FAG18BjMORwSLNxUW6rFZwGwP1+6GD1A==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-22.0.0.tgz",
+      "integrity": "sha512-M2dWN4MEFi+UyQcc9rb2ad2UXg982QjPj+GyCT81/o66N2NYwrkokcZN+SumChzUq5ZFMmcuX+f1IUWpyN9FPw==",
       "requires": {
         "d3-ease": "1.0.3",
         "d3-interpolate": "1.1.6",
         "d3-scale": "1.0.7",
         "d3-shape": "1.2.0",
         "d3-timer": "1.0.7",
-        "lodash": "4.17.5"
+        "lodash": "4.17.5",
+        "react-fast-compare": "1.0.0"
       }
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "builder-victory-component": "^5.1.2",
     "d3-shape": "^1.0.0",
     "lodash": "^4.17.5",
-    "victory-core": "^21.1.0"
+    "victory-core": "^22.0.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.13",


### PR DESCRIPTION

**Breaking Changes**

-[176](https://github.com/FormidableLabs/victory-pie/pull/176) Disable styles on data

This change deprecates Victory's ability to automatically pick up style attributes from the data object. This change will improve performance, but will be a breaking change for many users. Fortunately the upgrade path is simple:

If your data object looks like
```
data={[
  { x: 1, y: 1, fill: "red", opacity: 0.2 },
  ...
]}
```
Add the following functional styles:
```
style={{ data:  { fill: (d) => d.fill, opacity: (d) => d.opacity } }}
```
and everything will work as before.

Other changes:
-[177](https://github.com/FormidableLabs/victory-pie/pull/177) Audit lodash methods
