### PR TITLE
added radius prop to VictoryPie per issue #910

### DIFF
--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -24,6 +24,9 @@ const getColor = (style, colors, index) => {
 };
 
 const getRadius = (props, padding) => {
+  if (props.radius) {
+    return props.radius;
+  }
   return Math.min(
     props.width - padding.left - padding.right,
     props.height - padding.top - padding.bottom

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -52,7 +52,7 @@ const getCalculatedValues = (props) => {
   const radius = getRadius(props, padding);
   const offsetWidth = ((radius + padding.left) + (width - radius - padding.right)) / 2;
   const offsetHeight = ((radius + padding.top) + (height - radius - padding.bottom)) / 2;
-  const origin = { x: offsetWidth, y: offsetHeight };
+  const origin = props.origin || { x: offsetWidth, y: offsetHeight };
   const data = Data.getData(props);
   const slices = getSlices(props, data);
   const pathFunction = d3Shape.arc()

--- a/src/components/helper-methods.js
+++ b/src/components/helper-methods.js
@@ -50,9 +50,10 @@ const getCalculatedValues = (props) => {
   const colors = Array.isArray(colorScale) ? colorScale : Style.getColorScale(colorScale);
   const padding = Helpers.getPadding(props);
   const radius = getRadius(props, padding);
-  const offsetWidth = ((radius + padding.left) + (width - radius - padding.right)) / 2;
-  const offsetHeight = ((radius + padding.top) + (height - radius - padding.bottom)) / 2;
-  const origin = props.origin || { x: offsetWidth, y: offsetHeight };
+  const origin = props.origin || {
+    x: (padding.left - padding.right + width) / 2,
+    y: (padding.top - padding.bottom + height) / 2
+  };
   const data = Data.getData(props);
   const slices = getSlices(props, data);
   const pathFunction = d3Shape.arc()

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -102,16 +102,10 @@ class VictoryPie extends React.Component {
     labelRadius: PropTypes.oneOfType([ CustomPropTypes.nonNegative, PropTypes.func ]),
     labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
     name: PropTypes.string,
-    origin: PropTypes.arrayOf(PropTypes.shape({
-      x: PropTypes.oneOfType([
-        PropTypes.func,
-        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative])
-      ]),
-      y: PropTypes.oneOfType([
-        PropTypes.func,
-        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative])
-      ])
-    })),
+    origin: PropTypes.shape({
+      x: CustomPropTypes.nonNegative,
+      y: CustomPropTypes.nonNegative
+    }),
     padAngle: CustomPropTypes.nonNegative,
     padding: PropTypes.oneOfType([
       PropTypes.number,

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -102,6 +102,16 @@ class VictoryPie extends React.Component {
     labelRadius: PropTypes.oneOfType([ CustomPropTypes.nonNegative, PropTypes.func ]),
     labels: PropTypes.oneOfType([ PropTypes.func, PropTypes.array ]),
     name: PropTypes.string,
+    origin: PropTypes.arrayOf(PropTypes.shape({
+      x: PropTypes.oneOfType([
+        PropTypes.func,
+        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative])
+      ]),
+      y: PropTypes.oneOfType([
+        PropTypes.func,
+        CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative])
+      ])
+    })),
     padAngle: CustomPropTypes.nonNegative,
     padding: PropTypes.oneOfType([
       PropTypes.number,

--- a/src/components/victory-pie.js
+++ b/src/components/victory-pie.js
@@ -110,6 +110,7 @@ class VictoryPie extends React.Component {
         left: PropTypes.number, right: PropTypes.number
       })
     ]),
+    radius: CustomPropTypes.nonNegative,
     sharedEvents: PropTypes.shape({
       events: PropTypes.array,
       getEventState: PropTypes.func


### PR DESCRIPTION
Added support for radius prop to Victory-Pie. If radius prop is not present, radius is calculated from width, height, and padding as before.
-Added radius prop to propTypes in victory-pie.js
-Added check to getRadius in helper-methods.js

Closes https://github.com/FormidableLabs/victory/issues/910